### PR TITLE
chore: Update .pre-commit-config.yaml tools version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,17 @@
 repos:
   - repo: https://github.com/rtts/djhtml
-    rev: 'v1.5.2'  # replace with the latest tag on GitHub
+    rev: 3.0.7  # replace with the latest tag on GitHub
     hooks:
       - id: djhtml
-        entry: djhtml -i -t 2
+        entry: djhtml -t 2
         files: templates/.
       - id: djcss
         types: [scss]
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 24.10.0
     hooks:
       - id: black
   - repo: https://github.com/hadialqattan/pycln
-    rev: 'v2.3.0'
+    rev: 'v2.4.0'
     hooks:
       - id: pycln


### PR DESCRIPTION
In newer version of Python, `pycln` will error when run. The error is fixed after update to the latest version