### PR TITLE
fix: Fallback to download whole file when can’t get preview

### DIFF
--- a/judge/views/test_formatter/test_formatter.py
+++ b/judge/views/test_formatter/test_formatter.py
@@ -178,7 +178,7 @@ class DownloadTestFormatter(View):
         for i in range(len(preview_file)):
             response = response + (f"<p>{preview_file[i]}</p>\n")
 
-        files_list = [preview_file[0], preview_file[1]]
+        files_list = preview_file[:2] if len(preview_file) > 2 else preview_file
 
         return render(
             request,


### PR DESCRIPTION
This is a temporary fix. The content of the file still missing after the convert function