### PR TITLE
Fix quiz spectator bug and contest problems page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ plan/
 .claude/
 .claude-config/
 
-# Playwright
+# Playwright & temporary files
 /test-results/
 /playwright-report/
 /blob-report/
@@ -37,3 +37,4 @@ plan/
 /playwright/.auth/
 .playwright-mcp/
 playwright.config.ts
+tmp/

--- a/judge/views/quiz.py
+++ b/judge/views/quiz.py
@@ -1446,7 +1446,12 @@ class QuizDetail(TitleMixin, DetailView):
 
             # Check if in contest mode and show max submissions info
             # Use request.in_contest to respect the "Out contest" toggle
-            if getattr(self.request, "in_contest", False) and profile.current_contest:
+            # Spectators should not see contest-specific limits
+            if (
+                getattr(self.request, "in_contest", False)
+                and profile.current_contest
+                and not profile.current_contest.spectate
+            ):
                 contest_quiz = ContestProblem.objects.filter(
                     contest=profile.current_contest.contest, quiz=quiz
                 ).first()
@@ -1490,8 +1495,13 @@ class QuizStart(LoginRequiredMixin, View):
         contest_participation = None
 
         # Respect the "Out contest" toggle - only apply contest rules if in_contest is True
+        # Spectators (virtual=-1) should not be bound by contest rules
         in_contest = getattr(request, "in_contest", False)
-        if in_contest and profile.current_contest:
+        if (
+            in_contest
+            and profile.current_contest
+            and not profile.current_contest.spectate
+        ):
             # Check if this quiz is in the current contest
             contest_quiz = ContestProblem.objects.filter(
                 contest=profile.current_contest.contest, quiz=quiz
@@ -2227,7 +2237,11 @@ class QuizAttemptList(LoginRequiredMixin, TitleMixin, ListView):
         # - Contest mode: contest attempts only
         # - Standalone: standalone attempts only (no lesson, no contest)
         in_contest = getattr(self.request, "in_contest", False)
-        if in_contest and profile.current_contest:
+        if (
+            in_contest
+            and profile.current_contest
+            and not profile.current_contest.spectate
+        ):
             contest_quiz = ContestProblem.objects.filter(
                 contest=profile.current_contest.contest, quiz=quiz
             ).first()

--- a/templates/contest/problems.html
+++ b/templates/contest/problems.html
@@ -23,60 +23,66 @@
 {% endblock %}
 
 {% block middle_content %}
-  <div class="contest-problems">
-    <h2 style="margin-bottom: 0.2em"><i class="fa fa-fw fa-question-circle"></i>{{ _('Problems') }}</h2>
-    {% if is_in_contest %}
-      {% include "contest/contest-problem-table.html" %}
-    {% else %}
-      <table id="contest-problems" class="table">
-        <thead>
-          <tr>
-            <th>{{ _('Problem') }}</th>
-            <th>{{ _('Points') }}</th>
-            <th>{{ _('AC Rate') }}</th>
-            <th>{{ _('Users') }}</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for problem in contest_problems %}
+  {% if contest_problems %}
+    <div class="contest-problems">
+      <h2 style="margin-bottom: 0.2em"><i class="fa fa-fw fa-question-circle"></i>{{ _('Problems') }}</h2>
+      {% if is_in_contest %}
+        {% include "contest/contest-problem-table.html" %}
+      {% else %}
+        <table id="contest-problems" class="table">
+          <thead>
             <tr>
-              <td>
-                {% if problem.is_public or is_editor or request.user.is_superuser %}
-                  <a href="{{ url('problem_detail', problem.code) }}">{{ problem.translated_name(LANGUAGE_CODE) }}</a>
-                {% else %}
-                  {{ problem.translated_name(LANGUAGE_CODE) }}
-                {% endif %}
-              </td>
-              <td>{{ problem.points|floatformat }}{% if problem.partial %}p{% endif %}</td>
-              <td>{{ problem.ac_rate|floatformat(1) }}%</td>
-              <td>
-                {% if problem.is_public or is_editor or request.user.is_superuser %}
-                  <a href="{{ url('ranked_submissions', problem.code) }}">{{ problem.user_count }}</a>
-                {% else %}
-                  {{ problem.user_count }}
-                {% endif %}
-              </td>
-              <td>
-                {% if problem.is_public and problem.has_public_editorial() %}
-                  <a href="{{ url('problem_editorial', problem.code) }}">{{ _('Editorial') }}</a>
-                {% endif %}
-              </td>
+              <th>{{ _('Problem') }}</th>
+              <th>{{ _('Points') }}</th>
+              {% if contest.ended %}
+                <th>{{ _('AC Rate') }}</th>
+                <th>{{ _('Users') }}</th>
+              {% endif %}
+              <th></th>
             </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    {% endif %}
+          </thead>
+          <tbody>
+            {% for problem in contest_problems %}
+              <tr>
+                <td>
+                  {% if problem.is_public or is_editor or request.user.is_superuser %}
+                    <a href="{{ url('problem_detail', problem.code) }}">{{ problem.translated_name(LANGUAGE_CODE) }}</a>
+                  {% else %}
+                    {{ problem.translated_name(LANGUAGE_CODE) }}
+                  {% endif %}
+                </td>
+                <td>{{ problem.points|floatformat }}{% if problem.partial %}p{% endif %}</td>
+                {% if contest.ended %}
+                  <td>{{ problem.ac_rate|floatformat(1) }}%</td>
+                  <td>
+                    {% if problem.is_public or is_editor or request.user.is_superuser %}
+                      <a href="{{ url('ranked_submissions', problem.code) }}">{{ problem.user_count }}</a>
+                    {% else %}
+                      {{ problem.user_count }}
+                    {% endif %}
+                  </td>
+                {% endif %}
+                <td>
+                  {% if problem.is_public and problem.has_public_editorial() %}
+                    <a href="{{ url('problem_editorial', problem.code) }}">{{ _('Editorial') }}</a>
+                  {% endif %}
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% endif %}
 
-    <div style="margin-top: 1em; display: flex; justify-content: space-between; padding-right: 1em; font-size: 1.1em;">
-      <a href="{{ url('contest_problemset', contest.key) }}">
-        <i class="fa fa-book black"></i> {{ _('Complete problemset') }}
-      </a>
-      <a href="#" id="pdf_button">
-        <i class="fa fa-file-pdf red"></i> {{ _('View as PDF') }}
-      </a>
+      <div style="margin-top: 1em; display: flex; justify-content: space-between; padding-right: 1em; font-size: 1.1em;">
+        <a href="{{ url('contest_problemset', contest.key) }}">
+          <i class="fa fa-book black"></i> {{ _('Complete problemset') }}
+        </a>
+        <a href="#" id="pdf_button">
+          <i class="fa fa-file-pdf red"></i> {{ _('View as PDF') }}
+        </a>
+      </div>
     </div>
-  </div>
+  {% endif %}
 
   {% if contest_quizzes %}
     <div class="contest-quizzes" style="margin-top: 1em;">


### PR DESCRIPTION
- Fix spectators unable to start quiz in contest (was treating spectators as live participants, hitting contest time validation)
- Hide empty Problems section for quiz-only contests
- Hide AC Rate and Users columns until contest ends