### PR TITLE
Fix quiz-in-contest issues

### DIFF
--- a/judge/contest_format/base.py
+++ b/judge/contest_format/base.py
@@ -170,6 +170,9 @@ class BaseContestFormat(metaclass=ABCMeta):
             return
 
         # Recompute public score/cumtime from non-hidden entries only
+        # Note: cumtime uses sum which is correct for most formats (default,
+        # IOI, ICPC, ECOO). AtCoder uses max-based cumtime which may be
+        # slightly inaccurate when is_result_hidden is used.
         non_hidden_points = 0
         non_hidden_cumtime = 0
         for key, entry in format_data.items():

--- a/judge/utils/quiz_grading.py
+++ b/judge/utils/quiz_grading.py
@@ -343,6 +343,16 @@ def auto_grade_quiz_attempt(attempt) -> float:
     if hasattr(attempt, "contest_participation") and attempt.contest_participation:
         try:
             attempt.contest_participation.recompute_results()
+            # Post ranking-update event for live scoreboard
+            from judge.models import Contest
+            from judge import event_poster as event
+
+            contest = attempt.contest_participation.contest
+            if contest.scoreboard_visibility == Contest.SCOREBOARD_VISIBLE:
+                event.post(
+                    "contest_%s" % contest.key,
+                    {"type": "ranking-update"},
+                )
         except Exception:
             pass
 

--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -629,8 +629,13 @@ class ContestDetail(
                     is_submitted=True,
                 )
                 best = attempts.order_by("-score").first()
+                contest_score = None
+                if best and best.score is not None and best.max_score:
+                    contest_score = (
+                        float(best.score) / float(best.max_score) * cq.points
+                    )
                 quiz_user_data[cq.quiz.id] = {
-                    "best_score": best.score if best else None,
+                    "best_score": contest_score,
                     "best_attempt_id": best.id if best else None,
                     "attempt_count": attempts.count(),
                 }
@@ -722,8 +727,13 @@ class ContestProblems(ContestMixin, SolvedProblemMixin, TitleMixin, DetailView):
                     is_submitted=True,
                 )
                 best = attempts.order_by("-score").first()
+                contest_score = None
+                if best and best.score is not None and best.max_score:
+                    contest_score = (
+                        float(best.score) / float(best.max_score) * cq.points
+                    )
                 quiz_user_data[cq.quiz.id] = {
-                    "best_score": best.score if best else None,
+                    "best_score": contest_score,
                     "best_attempt_id": best.id if best else None,
                     "attempt_count": attempts.count(),
                 }

--- a/templates/contest/media-js.html
+++ b/templates/contest/media-js.html
@@ -107,7 +107,7 @@
 
   function getCellProblem($anchor) {
     var link = $anchor.attr('data-featherlight') || '';
-    if (!link.includes('submissions')) return null;
+    if (!link.includes('submissions') && !link.includes('quiz-attempts')) return null;
     var parts = link.split('/');
     return parts[parts.length - 2];
   }


### PR DESCRIPTION
- Fix scoreboard animation not showing for quiz submissions (snapshot was ignoring quiz-attempts URLs)
- Post ranking-update event on quiz grading for instant scoreboard refresh
- Fix quiz table showing raw quiz score instead of contest-scaled score
- Add cumtime note for AtCoder format limitation