### PR TITLE
Fix dark mode for buttons/text, improve moderation log table, add compute_cumtime for contest formats

### DIFF
--- a/judge/contest_format/atcoder.py
+++ b/judge/contest_format/atcoder.py
@@ -115,6 +115,18 @@ class AtCoderContestFormat(DefaultContestFormat):
         self.apply_result_hidden(participation, format_data)
         participation.save()
 
+    def compute_cumtime(self, format_data, entries=None):
+        cumtime = 0
+        penalty = 0
+        for key, entry in format_data.items():
+            if entries is not None and key not in entries:
+                continue
+            if entry.get("points", 0) > 0:
+                cumtime = max(cumtime, entry.get("time", 0))
+                if self.config["penalty"] and entry.get("penalty"):
+                    penalty += entry["penalty"] * self.config["penalty"] * 60
+        return cumtime + penalty
+
     def display_user_problem(self, participation, contest_problem, show_final=False):
         if contest_problem.quiz_id:
             format_key = f"quiz_{contest_problem.id}"

--- a/judge/contest_format/base.py
+++ b/judge/contest_format/base.py
@@ -135,6 +135,23 @@ class BaseContestFormat(metaclass=ABCMeta):
             else:
                 format_data[problem] = {"time": 0, "points": 0, "frozen": True}
 
+    def compute_cumtime(self, format_data, entries=None):
+        """
+        Compute cumtime from format_data entries. Each format can override
+        this to match its own cumtime logic (sum vs max, penalty, etc.).
+
+        :param format_data: The full format_data dict.
+        :param entries: If provided, only consider these keys. If None, use all.
+        :return: Computed cumtime value.
+        """
+        cumtime = 0
+        for key, entry in format_data.items():
+            if entries is not None and key not in entries:
+                continue
+            if entry.get("points", 0) > 0:
+                cumtime += entry.get("time", 0)
+        return max(cumtime, 0)
+
     def apply_result_hidden(self, participation, format_data):
         """
         Save full scores as final, then subtract is_result_hidden problems
@@ -151,13 +168,7 @@ class BaseContestFormat(metaclass=ABCMeta):
         # Save full values as final (if format didn't already)
         if not has_final:
             participation.score_final = participation.score
-            # participation.cumtime has problem times (+ penalty for ICPC/AtCoder)
-            # but may miss quiz times, so add those separately
-            quiz_cumtime = 0
-            for key, entry in format_data.items():
-                if key.startswith("quiz_") and entry.get("points", 0) > 0:
-                    quiz_cumtime += entry.get("time", 0)
-            participation.cumtime_final = max(participation.cumtime + quiz_cumtime, 0)
+            participation.cumtime_final = self.compute_cumtime(format_data)
             participation.format_data_final = copy.deepcopy(format_data)
 
         # Find is_result_hidden problems
@@ -169,28 +180,29 @@ class BaseContestFormat(metaclass=ABCMeta):
         if not hidden_cp_ids:
             return
 
-        # Recompute public score/cumtime from non-hidden entries only
-        # Note: cumtime uses sum which is correct for most formats (default,
-        # IOI, ICPC, ECOO). AtCoder uses max-based cumtime which may be
-        # slightly inaccurate when is_result_hidden is used.
-        non_hidden_points = 0
-        non_hidden_cumtime = 0
-        for key, entry in format_data.items():
-            # Check if this entry belongs to a hidden problem
+        # Determine which format_data keys are NOT hidden
+        non_hidden_keys = set()
+        for key in format_data:
             is_hidden = False
             for cp_id in hidden_cp_ids:
                 if key in (str(cp_id), f"quiz_{cp_id}"):
                     is_hidden = True
                     break
-            if not is_hidden and entry.get("points", 0) > 0:
-                non_hidden_points += entry.get("points", 0)
-                non_hidden_cumtime += entry.get("time", 0)
+            if not is_hidden:
+                non_hidden_keys.add(key)
+
+        # Recompute public score from non-hidden entries
+        non_hidden_points = sum(
+            entry.get("points", 0)
+            for key, entry in format_data.items()
+            if key in non_hidden_keys and entry.get("points", 0) > 0
+        )
 
         participation.score = round(
             max(non_hidden_points, 0),
             self.contest.points_precision,
         )
-        participation.cumtime = max(non_hidden_cumtime, 0)
+        participation.cumtime = self.compute_cumtime(format_data, non_hidden_keys)
 
     def calculate_quiz_scores(self, participation, format_data):
         """

--- a/judge/contest_format/ecoo.py
+++ b/judge/contest_format/ecoo.py
@@ -125,6 +125,16 @@ class ECOOContestFormat(DefaultContestFormat):
         self.apply_result_hidden(participation, format_data)
         participation.save()
 
+    def compute_cumtime(self, format_data, entries=None):
+        if not self.config.get("cumtime"):
+            return 0
+        cumtime = 0
+        for key, entry in format_data.items():
+            if entries is not None and key not in entries:
+                continue
+            cumtime += entry.get("time", 0)
+        return cumtime
+
     def display_user_problem(self, participation, contest_problem, show_final=False):
         if contest_problem.quiz_id:
             format_key = f"quiz_{contest_problem.id}"

--- a/judge/contest_format/icpc.py
+++ b/judge/contest_format/icpc.py
@@ -117,6 +117,18 @@ class ICPCContestFormat(DefaultContestFormat):
         self.apply_result_hidden(participation, format_data)
         participation.save()
 
+    def compute_cumtime(self, format_data, entries=None):
+        cumtime = 0
+        penalty = 0
+        for key, entry in format_data.items():
+            if entries is not None and key not in entries:
+                continue
+            if entry.get("points", 0) > 0:
+                cumtime += entry.get("time", 0)
+                if self.config["penalty"] and entry.get("penalty"):
+                    penalty += entry["penalty"] * self.config["penalty"] * 60
+        return max(0, cumtime + penalty)
+
     def display_user_problem(self, participation, contest_problem, show_final=False):
         if contest_problem.quiz_id:
             format_key = f"quiz_{contest_problem.id}"

--- a/judge/contest_format/ioi.py
+++ b/judge/contest_format/ioi.py
@@ -86,6 +86,11 @@ class IOIContestFormat(DefaultContestFormat):
         self.apply_result_hidden(participation, format_data)
         participation.save()
 
+    def compute_cumtime(self, format_data, entries=None):
+        if not self.config["cumtime"]:
+            return 0
+        return super().compute_cumtime(format_data, entries)
+
     def display_user_problem(self, participation, contest_problem, show_final=False):
         if contest_problem.quiz_id:
             format_key = f"quiz_{contest_problem.id}"

--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -280,7 +280,11 @@ class ContestList(
             get_recommended_contests_for_anonymous,
         )
 
-        if self.request.user.is_authenticated and self.request.profile:
+        if (
+            getattr(settings, "USE_ML", False)
+            and self.request.user.is_authenticated
+            and self.request.profile
+        ):
             scored = get_recommended_contests(self.request.profile, limit=100)
             if scored:
                 contest_ids = [cid for cid, _ in scored]

--- a/judge/views/problem.py
+++ b/judge/views/problem.py
@@ -395,7 +395,7 @@ class ProblemDetail(
                 self.profile, self.object
             )
 
-        if not self.in_contest:
+        if not self.in_contest and not (self.profile and self.profile.current_contest):
             context["contest_list"] = get_contests_for_problem(self.object.id)
 
         # Add comment context

--- a/resources/organization.scss
+++ b/resources/organization.scss
@@ -678,6 +678,39 @@
     }
 }
 
+// Moderation log table
+.moderation-log-table {
+    overflow-x: auto;
+
+    .table {
+        table-layout: fixed;
+    }
+
+    .table td,
+    .table th {
+        word-break: break-word;
+        overflow-wrap: break-word;
+    }
+
+    .col-time { width: 12%; }
+    .col-moderator { width: 13%; }
+    .col-action { width: 10%; }
+    .col-content { width: 20%; }
+    .col-preview { width: 25%; }
+    .col-reason { width: 20%; }
+}
+
+.expandable-text {
+    .text-full {
+        display: none;
+    }
+
+    .toggle-text {
+        cursor: pointer;
+        font-size: 0.9em;
+    }
+}
+
 // Mobile responsive for composer
 @media (max-width: 600px) {
     .post-composer {

--- a/templates/course/edit_lesson_new_window.html
+++ b/templates/course/edit_lesson_new_window.html
@@ -107,7 +107,7 @@
         </a>
       </div>
       {% if current_user_role == 'ADMIN' or current_user_role == 'TE' %}
-        <button type="submit" name="delete_lesson" class="btn btn-danger" style="padding: 0.5em 1em; border: none; border-radius: 4px; cursor: pointer; background-color: #d9534f; color: white;" onclick="return confirm('{{_('Are you sure you want to delete this lesson?')}}')">
+        <button type="submit" name="delete_lesson" class="action-btn background-red" onclick="return confirm('{{_('Are you sure you want to delete this lesson?')}}')">
           <i class="fa fa-trash"></i> {{_('Delete Lesson')}}
         </button>
       {% endif %}

--- a/templates/organization/blog/pending.html
+++ b/templates/organization/blog/pending.html
@@ -29,7 +29,7 @@
   </div>
 
   {% if not blogs %}
-    <div class="empty-message" style="text-align: center; padding: 2em; color: #888;">
+    <div class="empty-message gray" style="text-align: center; padding: 2em;">
       <i class="fa {% if current_tab == 'rejected' %}fa-check-circle{% else %}fa-inbox{% endif %}" style="font-size: 3em;"></i>
       <p>{% if current_tab == 'rejected' %}{{ _('No rejected posts.') }}{% else %}{{ _('No pending posts.') }}{% endif %}</p>
     </div>
@@ -55,8 +55,8 @@
         <a href="{{ url('blog_post', post.id, post.slug) }}">{{ post.title }}</a>
       </h2>
       {% if current_tab == 'rejected' and post.rejection_info %}
-        <div class="rejection-info" style="background: rgba(255, 0, 0, 0.05); border-left: 3px solid #dc3545; padding: 0.5em 1em; margin-bottom: 0.5em; font-size: 0.9em;">
-          <i class="fa fa-times-circle" style="color: #dc3545;"></i>
+        <div class="rejection-info" style="border-left: 3px solid; padding: 0.5em 1em; margin-bottom: 0.5em; font-size: 0.9em;">
+          <i class="fa fa-times-circle red"></i>
           <strong>{{ _('Rejected') }}</strong>
           {{ _('by') }}
           {% if post.rejection_info.is_automated %}
@@ -71,7 +71,7 @@
           &#8226;
           {{ relative_time(post.rejection_info.created_at) }}
           {% if post.rejection_info.reason %}
-            <div style="margin-top: 0.3em; color: #666;">
+            <div class="gray" style="margin-top: 0.3em;">
               <i class="fa fa-comment"></i> {{ post.rejection_info.reason }}
             </div>
           {% endif %}

--- a/templates/organization/courses.html
+++ b/templates/organization/courses.html
@@ -99,7 +99,7 @@
           {% if course.course_image %}
             <img src="{{ course.course_image.url }}" alt="{{ course.name }}" class="course-image">
           {% else %}
-            <div class="course-image" style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);"></div>
+            <div class="course-image" style="background: linear-gradient(135deg, #667eea, #764ba2);"></div>
           {% endif %}
 
           <a href="{{ url('course_detail', course.slug) }}" class="course-name">
@@ -126,11 +126,11 @@
             </div>
 
             {% if course.is_open %}
-              <div style="color: green; margin-top: 5px;">
+              <div class="green" style="margin-top: 5px;">
                 <i class="fa fa-check-circle"></i> {{ _('Open for enrollment') }}
               </div>
             {% else %}
-              <div style="color: #666; margin-top: 5px;">
+              <div class="gray" style="margin-top: 5px;">
                 <i class="fa fa-lock"></i> {{ _('Closed for enrollment') }}
               </div>
             {% endif %}

--- a/templates/organization/moderation_log.html
+++ b/templates/organization/moderation_log.html
@@ -1,117 +1,153 @@
 {% extends "organization/home-base.html" %}
 
+{% block org_js %}
+  <script>
+    $(function() {
+      $('.moderation-log-table').on('click', '.toggle-text', function(e) {
+        e.preventDefault();
+        var $this = $(this);
+        var $container = $this.closest('.expandable-text');
+        var $short = $container.find('.text-short');
+        var $full = $container.find('.text-full');
+
+        if ($full.is(':visible')) {
+          $full.hide();
+          $short.show();
+          $this.text('{{ _("...More") }}');
+        } else {
+          $short.hide();
+          $full.show();
+          $this.text('{{ _("Less") }}');
+        }
+      });
+    });
+  </script>
+{% endblock %}
+
+{% macro expandable(short_text, full_text) %}
+  {% if full_text|length > 80 %}
+    {% set display_text = short_text[:-3] if short_text.endswith('...') else short_text %}
+    <span class="expandable-text">
+      <span class="text-short gray">{{ display_text }}</span>
+      <span class="text-full gray">{{ full_text }}</span>
+      <a class="toggle-text">{{ _("...More") }}</a>
+    </span>
+  {% else %}
+    <span class="gray">{{ full_text }}</span>
+  {% endif %}
+{% endmacro %}
+
 {% block middle_content %}
   {% if logs %}
-    <table class="table striped">
-      <thead>
-        <tr>
-          <th>{{ _('Time') }}</th>
-          <th>{{ _('Moderator') }}</th>
-          <th>{{ _('Action') }}</th>
-          <th>{{ _('Content') }}</th>
-          <th>{{ _('Preview') }}</th>
-          <th>{{ _('Reason') }}</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for log in logs %}
+    <div class="moderation-log-table">
+      <table class="table striped">
+        <thead>
           <tr>
-            <td title="{{ log.created_at }}">
-              {{ relative_time(log.created_at) }}
-            </td>
-            <td>
-              {% if log.is_automated %}
-                <span class="badge background-blue white" style="padding: 2px 6px; border-radius: 3px;">
-                  <i class="fa fa-robot"></i> {{ _('LLM') }}
-                </span>
-              {% elif log.moderator %}
-                {{ link_user(log.moderator) }}
-              {% else %}
-                <span class="gray">{{ _('Unknown') }}</span>
-              {% endif %}
-            </td>
-            <td>
-              {% if log.action == 'hide_comment' %}
-                <span class="badge background-red white" style="padding: 2px 6px; border-radius: 3px;">
-                  <i class="fa fa-eye-slash"></i> {{ _('Hide') }}
-                </span>
-              {% elif log.action == 'unhide_comment' %}
-                <span class="badge background-green white" style="padding: 2px 6px; border-radius: 3px;">
-                  <i class="fa fa-eye"></i> {{ _('Unhide') }}
-                </span>
-              {% elif log.action == 'keep_comment' %}
-                <span class="badge background-green white" style="padding: 2px 6px; border-radius: 3px;">
-                  <i class="fa fa-check"></i> {{ _('Keep') }}
-                </span>
-              {% elif log.action == 'approve_post' %}
-                <span class="badge background-green white" style="padding: 2px 6px; border-radius: 3px;">
-                  <i class="fa fa-check"></i> {{ _('Approve') }}
-                </span>
-              {% elif log.action == 'reject_post' %}
-                <span class="badge background-red white" style="padding: 2px 6px; border-radius: 3px;">
-                  <i class="fa fa-times"></i> {{ _('Reject') }}
-                </span>
-              {% elif log.action == 'skip' %}
-                <span class="badge background-gray white" style="padding: 2px 6px; border-radius: 3px;">
-                  <i class="fa fa-forward"></i> {{ _('Skipped') }}
-                </span>
-              {% else %}
-                {{ log.get_action_display() }}
-              {% endif %}
-            </td>
-            <td>
-              {% set content_obj = log.content_object %}
-              {% if content_obj %}
-                {% if log.content_type.model == 'comment' %}
-                  <a href="{{ content_obj.get_absolute_url() }}">
-                    {{ _('Comment') }} #{{ log.object_id }}
-                  </a>
-                  {% if content_obj.author %}
-                    {{ _('by') }} {{ link_user(content_obj.author) }}
-                  {% endif %}
-                {% elif log.content_type.model == 'blogpost' %}
-                  <a href="{{ content_obj.get_absolute_url() }}">{{ content_obj.title[:50] }}</a>
+            <th class="col-time">{{ _('Time') }}</th>
+            <th class="col-moderator">{{ _('Moderator') }}</th>
+            <th class="col-action">{{ _('Action') }}</th>
+            <th class="col-content">{{ _('Content') }}</th>
+            <th class="col-preview">{{ _('Preview') }}</th>
+            <th class="col-reason">{{ _('Reason') }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for log in logs %}
+            <tr>
+              <td title="{{ log.created_at }}">
+                {{ relative_time(log.created_at) }}
+              </td>
+              <td>
+                {% if log.is_automated %}
+                  <span class="badge background-blue white" style="padding: 2px 6px; border-radius: 3px;">
+                    <i class="fa fa-robot"></i> {{ _('LLM') }}
+                  </span>
+                {% elif log.moderator %}
+                  {{ link_user(log.moderator) }}
                 {% else %}
-                  {{ log.content_type.model }} #{{ log.object_id }}
+                  <span class="gray">{{ _('Unknown') }}</span>
                 {% endif %}
-              {% else %}
-                <span class="gray">{{ log.content_type.model }} #{{ log.object_id }} ({{ _('deleted') }})</span>
-              {% endif %}
-            </td>
-            <td>
-              {% set content_obj = log.content_object %}
-              {% if content_obj %}
-                {% if log.content_type.model == 'comment' and content_obj.body %}
-                  <span title="{{ content_obj.body[:500] }}" class="gray">
-                    {{ content_obj.body|truncate(80, True) }}
+              </td>
+              <td>
+                {% if log.action == 'hide_comment' %}
+                  <span class="badge background-red white" style="padding: 2px 6px; border-radius: 3px;">
+                    <i class="fa fa-eye-slash"></i> {{ _('Hide') }}
                   </span>
-                {% elif log.content_type.model == 'blogpost' and content_obj.content %}
-                  <span title="{{ content_obj.content[:500] }}" class="gray">
-                    {{ content_obj.content|striptags|truncate(80, True) }}
+                {% elif log.action == 'unhide_comment' %}
+                  <span class="badge background-green white" style="padding: 2px 6px; border-radius: 3px;">
+                    <i class="fa fa-eye"></i> {{ _('Unhide') }}
                   </span>
+                {% elif log.action == 'keep_comment' %}
+                  <span class="badge background-green white" style="padding: 2px 6px; border-radius: 3px;">
+                    <i class="fa fa-check"></i> {{ _('Keep') }}
+                  </span>
+                {% elif log.action == 'approve_post' %}
+                  <span class="badge background-green white" style="padding: 2px 6px; border-radius: 3px;">
+                    <i class="fa fa-check"></i> {{ _('Approve') }}
+                  </span>
+                {% elif log.action == 'reject_post' %}
+                  <span class="badge background-red white" style="padding: 2px 6px; border-radius: 3px;">
+                    <i class="fa fa-times"></i> {{ _('Reject') }}
+                  </span>
+                {% elif log.action == 'skip' %}
+                  <span class="badge background-gray white" style="padding: 2px 6px; border-radius: 3px;">
+                    <i class="fa fa-forward"></i> {{ _('Skipped') }}
+                  </span>
+                {% else %}
+                  {{ log.get_action_display() }}
+                {% endif %}
+              </td>
+              <td>
+                {% set content_obj = log.content_object %}
+                {% if content_obj %}
+                  {% if log.content_type.model == 'comment' %}
+                    <a href="{{ content_obj.get_absolute_url() }}">
+                      {{ _('Comment') }} #{{ log.object_id }}
+                    </a>
+                    {% if content_obj.author %}
+                      {{ _('by') }} {{ link_user(content_obj.author) }}
+                    {% endif %}
+                  {% elif log.content_type.model == 'blogpost' %}
+                    <a href="{{ content_obj.get_absolute_url() }}">{{ content_obj.title[:50] }}</a>
+                  {% else %}
+                    {{ log.content_type.model }} #{{ log.object_id }}
+                  {% endif %}
+                {% else %}
+                  <span class="gray">{{ log.content_type.model }} #{{ log.object_id }} ({{ _('deleted') }})</span>
+                {% endif %}
+              </td>
+              <td>
+                {% set content_obj = log.content_object %}
+                {% if content_obj %}
+                  {% if log.content_type.model == 'comment' and content_obj.body %}
+                    {{ expandable(content_obj.body|truncate(80, True), content_obj.body[:500]) }}
+                  {% elif log.content_type.model == 'blogpost' and content_obj.content %}
+                    {% set stripped = content_obj.content|striptags %}
+                    {{ expandable(stripped|truncate(80, True), stripped[:500]) }}
+                  {% else %}
+                    <span class="gray">-</span>
+                  {% endif %}
                 {% else %}
                   <span class="gray">-</span>
                 {% endif %}
-              {% else %}
-                <span class="gray">-</span>
-              {% endif %}
-            </td>
-            <td>
-              {% if log.reason %}
-                <span title="{{ log.reason }}">{{ log.reason[:80] }}{% if log.reason|length > 80 %}...{% endif %}</span>
-              {% else %}
-                <span class="gray">-</span>
-              {% endif %}
-            </td>
-          </tr>
-        {% endfor %}
-      </tbody>
-    </table>
+              </td>
+              <td>
+                {% if log.reason %}
+                  {{ expandable(log.reason[:80], log.reason) }}
+                {% else %}
+                  <span class="gray">-</span>
+                {% endif %}
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
 
     {% include "list-pages.html" %}
   {% else %}
     <div class="empty-message">
-      <i class="fa fa-check-circle" style="font-size: 3em; color: #ccc;"></i>
+      <i class="fa fa-check-circle gray" style="font-size: 3em;"></i>
       <p>{{ _('No moderation actions recorded yet.') }}</p>
     </div>
   {% endif %}

--- a/templates/problem/add.html
+++ b/templates/problem/add.html
@@ -36,24 +36,6 @@
       }
     }
 
-    .small-action-btn {
-      padding: 4px 10px;
-      font-size: 0.85em;
-      font-weight: normal;
-      cursor: pointer;
-      border: 1px solid #ccc;
-      border-radius: 4px;
-      background: #f8f8f8;
-      transition: background 0.2s;
-    }
-
-    .small-action-btn:hover {
-      background: #e8e8e8;
-    }
-
-    .small-action-btn i {
-      margin-right: 4px;
-    }
   </style>
 {% endblock %}
 
@@ -176,7 +158,7 @@
           <div class="form-row">
             <label for="{{ form.description.id_for_label }}">
               <b>{{ _('Problem Description') }}{% if form.description.field.required %}<span class="red"> * </span>{% endif %}:</b>
-              <button type="button" id="use-template-btn" class="small-action-btn" style="margin-left: 10px;">
+              <button type="button" id="use-template-btn" class="action-btn small" style="margin-left: 10px;">
                 <i class="fa fa-file-alt"></i> {{ _('Use Template') }}
               </button>
             </label>

--- a/templates/ticket/edit-assignees.html
+++ b/templates/ticket/edit-assignees.html
@@ -1,18 +1,18 @@
 {{ form.media.css }}
 
 <div style="padding: 20px; max-width: 500px; min-width: 400px;">
-  <div style="font-size: 18px; font-weight: bold; margin-bottom: 15px; color: #333; border-bottom: 1px solid #ddd; padding-bottom: 10px;">
+  <div style="font-size: 18px; font-weight: bold; margin-bottom: 15px; border-bottom: 1px solid; padding-bottom: 10px;">
     {{ _('Edit Ticket Assignees') }}
   </div>
 
   <form id="edit-assignees" action="{{ url('ticket_assignees', ticket.id) }}" method="post">
     {% csrf_token %}
     <div style="margin-bottom: 20px;">
-      <label for="{{ form.assignees.id_for_label }}" style="display: block; font-weight: bold; margin-bottom: 8px; color: #333;">
+      <label for="{{ form.assignees.id_for_label }}" style="display: block; font-weight: bold; margin-bottom: 8px;">
         {{ form.assignees.label }}
       </label>
       {{ form.assignees }}
-      <div style="font-size: 12px; color: #666; margin-top: 5px;">
+      <div class="gray" style="font-size: 12px; margin-top: 5px;">
         {{ _('Select users to assign to this ticket. Start typing to search.') }}
       </div>
     </div>


### PR DESCRIPTION
- Fix hardcoded colors in buttons and text across templates for dark mode compatibility
- Fix moderation log table overflow with fixed layout and expandable text preview
- Move moderation log styles to organization.scss
- Add compute_cumtime() virtual method for per-format cumtime calculation in apply_result_hidden
- Add USE_ML guard for /contests/recommended
- Hide contest list on problem page when user is in contest mode