### PR TITLE
Fix crash when user.about is None on org members page

### DIFF
--- a/templates/user/users-table.html
+++ b/templates/user/users-table.html
@@ -50,7 +50,7 @@
   <td class="user-contribution">{{ user.contribution_points }}</td>
   <td>
     <div class="about-td">
-      {{ user.about|markdown(lazy_load=True)|reference|str|safe }}
+      {% if user.about %}{{ user.about|markdown(lazy_load=True)|reference|str|safe }}{% endif %}
     </div>
   </td>
 {% endblock %}


### PR DESCRIPTION
Guard markdown filter with None check to prevent AttributeError when about field is NULL in the database.