### PR TITLE
chore: add self-contained Docker dev-local environment

### DIFF
--- a/.docker/dev-local/.dockerignore
+++ b/.docker/dev-local/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.gitignore
+.sass-cache
+node_modules
+__pycache__
+*.py[co]
+*.mo
+.DS_Store
+sass_processed
+dmoj/local_settings.py

--- a/.docker/dev-local/.gitattributes
+++ b/.docker/dev-local/.gitattributes
@@ -1,0 +1,30 @@
+# Shell scripts and entrypoints MUST use LF on all platforms.
+# Without this, Windows Git will convert to CRLF and Docker will fail
+# with "/bin/bash^M: bad interpreter".
+
+*.sh        text eol=lf
+*.env       text eol=lf
+Dockerfile* text eol=lf
+
+# Standard text normalization
+*.py        text eol=lf
+*.html      text eol=lf
+*.scss      text eol=lf
+*.css       text eol=lf
+*.js        text eol=lf
+*.json      text eol=lf
+*.md        text eol=lf
+*.yml       text eol=lf
+*.yaml      text eol=lf
+*.txt       text eol=lf
+
+# Binaries — no conversion
+*.png       binary
+*.jpg       binary
+*.gif       binary
+*.ico       binary
+*.woff      binary
+*.woff2     binary
+*.ttf       binary
+*.eot       binary
+*.mo        binary

--- a/.docker/dev-local/Dockerfile
+++ b/.docker/dev-local/Dockerfile
@@ -1,0 +1,38 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+# Step 1 from README: system packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git gcc g++ make \
+    python3-dev python3-pip \
+    libxml2-dev libxslt1-dev \
+    zlib1g-dev gettext curl \
+    pkg-config \
+    # mysqlclient native driver
+    libmysqlclient-dev default-libmysqlclient-dev \
+    # lupa (Python-Lua bridge in requirements.txt)
+    liblua5.4-dev \
+    && curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# CSS build tools (exact from README)
+RUN npm install -g sass postcss-cli postcss autoprefixer --silent
+
+WORKDIR /code
+
+# Python deps — cached layer, only rebuilds when requirements.txt changes
+COPY requirements.txt .
+RUN pip3 install --no-cache-dir -r requirements.txt mysqlclient
+
+# Path is relative to build context (online-judge/)
+COPY .docker/dev-local/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+EXPOSE 8001
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["python3", "manage.py", "runserver", "0.0.0.0:8001"]

--- a/.docker/dev-local/HANDOFF.md
+++ b/.docker/dev-local/HANDOFF.md
@@ -1,0 +1,86 @@
+# LQDOJ Handoff
+
+## Setup Status: Complete
+
+Site runs at `http://localhost:8001`.
+
+### Option A — Docker (recommended, zero lib-mismatch pain) — see `online-judge/.docker/dev-local/README.md`
+
+Runs a real Linux environment (Python 3.11 / Debian Bookworm / MariaDB 10.11) identical to the server. Code is live-mounted so edits on Mac appear instantly.
+
+**First-time setup:**
+```bash
+cd ~/hobby-projects/LQDOJ
+
+# Start DB + services, wait for healthy
+docker compose up -d db memcached redis
+
+# Migrate database (once)
+docker compose run --rm web python3 manage.py migrate
+
+# Create admin user (once)
+docker compose run --rm web python3 manage.py createsuperuser
+
+# Collect static files (once, and after any static changes)
+docker compose run --rm web python3 manage.py collectstatic --noinput
+
+# Start the dev server
+docker compose up web
+```
+
+**Daily usage:**
+```bash
+cd ~/hobby-projects/LQDOJ
+docker compose -f online-judge/.docker/dev-local/docker-compose.yml up
+```
+
+**One-off management commands:**
+```bash
+docker compose -f online-judge/.docker/dev-local/docker-compose.yml run --rm web python3 manage.py <command>
+```
+
+**Tear down completely** (keeps DB data):
+```bash
+docker compose -f online-judge/.docker/dev-local/docker-compose.yml down
+```
+**Nuke DB data too:**
+```bash
+docker compose -f online-judge/.docker/dev-local/docker-compose.yml down -v
+```
+
+---
+
+### Option B — Native Mac (legacy, avoid for new work)
+
+- DB: MariaDB via Homebrew, user `dmoj`, password `dmoj`, database `dmoj`
+- Venv: `~/hobby-projects/LQDOJ/dmojsite` (Python 3.14 — causes occasional Django deserialization bugs)
+- `demo` fixture skipped — Python 3.14 / Django 4.2 deserialization bug
+
+```bash
+source ~/hobby-projects/LQDOJ/dmojsite/bin/activate
+cd ~/hobby-projects/LQDOJ/online-judge
+python3 manage.py runserver 0.0.0.0:8001
+```
+
+---
+
+## Active Work: Code Quality PRs
+
+Three branches created off `master`:
+
+| Branch | PR Title | Status |
+|--------|----------|--------|
+| `chore/extract-constants` | Extract magic numbers into named constants | **ABANDONED** — most constants already exist (submission statuses on `Submission` model, priorities named in `judgeapi.py`). Not enough real duplication to justify. Delete this branch. |
+| `chore/structured-logging` | Replace scattered logging with structured JSON logging | Todo |
+| `chore/add-mypy` | Add mypy type checking to pre-commit pipeline | Todo |
+
+---
+
+## Architecture Notes
+
+See conversation history for full architecture analysis. Key points:
+- Judging pipeline: Browser → Django → Bridge (TCP/zlib) → Judge Server → event daemon → Browser
+- 3-layer cache: L0 (request-scoped thread-local), L1 (memcached), L2 (`@cache_wrapper`)
+- Celery + Redis for background tasks
+- Jinja2 templates + jQuery + Socket.IO frontend
+- `libseccomp` is Linux-only; judge sandbox won't run on macOS

--- a/.docker/dev-local/README.md
+++ b/.docker/dev-local/README.md
@@ -1,0 +1,259 @@
+# Docker Dev Guide
+
+Runs an Ubuntu 22.04 environment matching the production server.
+All code is live-mounted so edits on your host appear instantly inside the container.
+
+All Docker config lives here: `online-judge/.docker/dev-local/`
+
+---
+
+## Platform support
+
+| Platform | Status | Notes |
+|---|---|---|
+| **Linux (Ubuntu 22.04+)** | ✅ Full support | Install Docker Engine, no extra steps |
+| **macOS (Intel + Apple Silicon)** | ✅ Full support | Install Docker Desktop; ARM64 images used natively on M-series |
+| **Windows 10/11** | ✅ Full support | Requires Docker Desktop + **WSL 2 backend** (see below) |
+
+### Windows prerequisites
+
+1. Enable WSL 2: `wsl --install` in PowerShell (admin), then reboot
+2. Install [Docker Desktop](https://www.docker.com/products/docker-desktop/) — enable the WSL 2 backend in Settings → General
+3. Clone the repo **inside WSL** (not on the Windows NTFS drive) to avoid volume-mount slowness:
+   ```bash
+   # Inside WSL terminal
+   cd ~
+   git clone <repo-url> LQDOJ
+   ```
+4. Run all commands from the WSL terminal, not PowerShell
+
+> **Line endings** — `.gitattributes` at the repo root forces LF on all shell scripts.
+> If you cloned before it existed, run: `git rm --cached -r . && git reset --hard`
+
+---
+
+## How to run
+
+All commands below use `-f` so you can run them from **the repo root** (`LQDOJ/`).
+If you prefer, `cd online-judge/.docker/dev-local` and drop the `-f` flag entirely.
+
+```bash
+# Shorthand — set once per terminal session to avoid typing -f every time
+export COMPOSE_FILE=online-judge/.docker/dev-local/docker-compose.yml
+```
+
+---
+
+## First-time setup
+
+```bash
+cd ~/hobby-projects/LQDOJ
+
+# Build the image (once, or after Dockerfile / requirements.txt changes)
+docker compose -f online-judge/.docker/dev-local/docker-compose.yml build
+
+# Start everything
+docker compose -f online-judge/.docker/dev-local/docker-compose.yml up
+```
+
+On first start the entrypoint automatically:
+1. Compiles SCSS → CSS
+2. Collects static files
+3. Runs `migrate`
+4. Loads `navbar` + `language_small` fixtures (only if DB is empty)
+5. Starts `runserver` on **http://localhost:8001**
+
+Then in a separate terminal:
+```bash
+# Create your admin account (once)
+docker compose -f online-judge/.docker/dev-local/docker-compose.yml \
+    run --rm web python3 manage.py createsuperuser
+
+# Seed the DB with 60 users / 210 problems / 27 contests
+docker compose -f online-judge/.docker/dev-local/docker-compose.yml \
+    run --rm web python3 manage.py seed_dev_data
+```
+
+---
+
+## Daily workflow
+
+```bash
+COMPOSE_FILE=online-judge/.docker/dev-local/docker-compose.yml
+
+docker compose -f $COMPOSE_FILE up        # start; Ctrl-C to stop
+docker compose -f $COMPOSE_FILE down      # stop (DB data kept)
+docker compose -f $COMPOSE_FILE down -v   # stop + wipe DB completely
+```
+
+---
+
+## Rebuild reference
+
+### After Python / template changes
+No action needed. Django `runserver` auto-reloads on every file save.
+
+---
+
+### After adding or changing a model (migrations)
+
+```bash
+docker compose -f online-judge/.docker/dev-local/docker-compose.yml \
+    run --rm web python3 manage.py makemigrations
+docker compose -f online-judge/.docker/dev-local/docker-compose.yml \
+    run --rm web python3 manage.py migrate
+```
+
+---
+
+### After editing SCSS (`.scss` files)
+
+```bash
+docker compose -f online-judge/.docker/dev-local/docker-compose.yml \
+    run --rm --entrypoint bash web -c "
+  sass resources:sass_processed --no-source-map --style=expanded --quiet
+  postcss sass_processed/style.css sass_processed/content-description.css \
+          sass_processed/table.css sass_processed/ranks.css \
+          --use autoprefixer -d resources --no-map
+"
+```
+
+CSS lands in `online-judge/resources/` (live-mounted). Hard-refresh the browser.
+
+---
+
+### After editing static files (JS, images, compiled CSS)
+
+```bash
+docker compose -f online-judge/.docker/dev-local/docker-compose.yml \
+    exec web python3 manage.py collectstatic --noinput -v 0
+```
+
+Hard-refresh (Cmd/Ctrl + Shift + R) after running.
+
+> Must be run after every SCSS recompile AND after any direct edit to JS or images.
+
+---
+
+### After editing `requirements.txt`
+
+```bash
+docker compose -f online-judge/.docker/dev-local/docker-compose.yml build
+docker compose -f online-judge/.docker/dev-local/docker-compose.yml up
+```
+
+---
+
+### After editing `Dockerfile` or `docker-entrypoint.sh`
+
+```bash
+docker compose -f online-judge/.docker/dev-local/docker-compose.yml build
+docker compose -f online-judge/.docker/dev-local/docker-compose.yml up
+```
+
+---
+
+### After editing `local_settings_docker.py`
+
+```bash
+docker compose -f online-judge/.docker/dev-local/docker-compose.yml restart web
+```
+
+Settings are read at startup — restart is enough, no rebuild needed.
+
+---
+
+### After pulling new code with DB migrations
+
+```bash
+docker compose -f online-judge/.docker/dev-local/docker-compose.yml \
+    run --rm web python3 manage.py migrate
+```
+
+---
+
+## Useful one-liners
+
+```bash
+CF="-f online-judge/.docker/dev-local/docker-compose.yml"
+
+# Open a shell inside the running container
+docker compose $CF exec web bash
+
+# Run any management command
+docker compose $CF run --rm web python3 manage.py <command>
+
+# Tail Django logs
+docker compose $CF logs -f web
+
+# Re-seed dev data from scratch
+docker compose $CF run --rm web python3 manage.py seed_dev_data --clear
+
+# Django shell
+docker compose $CF run --rm web python3 manage.py shell
+
+# Check for config errors
+docker compose $CF run --rm web python3 manage.py check
+```
+
+---
+
+## File map
+
+```
+online-judge/.docker/dev-local/
+├── docker-compose.yml       — service definitions
+├── Dockerfile               — Ubuntu 22.04 image + Python + Node
+├── docker-entrypoint.sh     — startup script (SCSS, migrate, fixtures)
+├── .dockerignore            — excludes from build context
+├── local_settings_docker.py — Django settings (mounted as local_settings.py)
+├── mariadb-init/
+│   └── 01-timezone.sh       — loads tz data into MariaDB on first start
+└── README.md                — this file
+```
+
+---
+
+## Services and ports
+
+| Service    | Host port | What it is               |
+|------------|-----------|--------------------------|
+| `web`      | **8001**  | Django runserver         |
+| `db`       | —         | MariaDB 10.11 (internal) |
+| `memcached`| —         | Cache (internal)         |
+| `redis`    | —         | Celery broker (internal) |
+
+---
+
+## Troubleshooting
+
+**"Table doesn't exist" after pulling new code**
+```bash
+docker compose -f online-judge/.docker/dev-local/docker-compose.yml \
+    run --rm web python3 manage.py migrate
+```
+
+**Port 8001 already in use**
+```bash
+lsof -i :8001                          # macOS / Linux
+netstat -ano | findstr 8001            # Windows PowerShell
+```
+
+**CSS looks wrong after an SCSS change**
+Re-run the SCSS compile command above, then hard-refresh.
+
+**Windows: `/bin/bash^M: bad interpreter`**
+Shell scripts have Windows line endings. Fix:
+```bash
+# Inside WSL
+dos2unix online-judge/.docker/dev-local/docker-entrypoint.sh
+dos2unix online-judge/.docker/dev-local/mariadb-init/01-timezone.sh
+docker compose -f online-judge/.docker/dev-local/docker-compose.yml build
+```
+
+**Full reset**
+```bash
+docker compose -f online-judge/.docker/dev-local/docker-compose.yml down -v
+docker compose -f online-judge/.docker/dev-local/docker-compose.yml build
+docker compose -f online-judge/.docker/dev-local/docker-compose.yml up
+```

--- a/.docker/dev-local/docker-compose.yml
+++ b/.docker/dev-local/docker-compose.yml
@@ -49,5 +49,32 @@ services:
       redis:
         condition: service_started
 
+  # Bridge: relay between Django web server and judge(s).
+  bridge:
+    build:
+      context: ../../..                              # = LQDOJ/ — Dockerfile does COPY online-judge /app
+      dockerfile: online-judge/.docker/bridge/Dockerfile
+    restart: unless-stopped
+    working_dir: /app
+    volumes:
+      - ../..:/app                                   # online-judge/ → /app (live-mount)
+      - ./local_settings_docker.py:/app/dmoj/local_settings.py
+    depends_on:
+      db:
+        condition: service_healthy
+
+  # Judge: sandboxed code execution.
+  # Build the image once with:  cd judge-server/.docker && make judge-tier1
+  judge:
+    image: ${JUDGE_IMAGE:-vnoj/judge-tier1:latest}
+    restart: unless-stopped
+    cap_add:
+      - SYS_PTRACE
+    volumes:
+      - ../../../problems:/problems                  # LQDOJ/problems
+    command: ["run", "-c", "/problems/__conf__/general.yml", "--no-watchdog", "bridge", "judge1"]
+    depends_on:
+      - bridge
+
 volumes:
   db_data:

--- a/.docker/dev-local/docker-compose.yml
+++ b/.docker/dev-local/docker-compose.yml
@@ -1,0 +1,53 @@
+name: lqdoj   # keeps volume names stable regardless of which directory you run from
+
+services:
+  db:
+    image: mariadb:10.11
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: dmoj
+      MYSQL_USER: dmoj
+      MYSQL_PASSWORD: dmoj
+    volumes:
+      - db_data:/var/lib/mysql
+      - ./mariadb-init:/docker-entrypoint-initdb.d
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      start_period: 30s
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  memcached:
+    image: memcached:1.6-alpine
+    restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+
+  web:
+    build:
+      context: ../..                            # = online-judge/
+      dockerfile: .docker/dev-local/Dockerfile  # relative to context
+    restart: unless-stopped
+    working_dir: /code
+    volumes:
+      - ../..:/code                                                    # online-judge/ → /code
+      - ./local_settings_docker.py:/code/dmoj/local_settings.py       # dev settings
+      - ../../../media:/media                                          # LQDOJ/media
+      - ../../../static:/static                                        # LQDOJ/static
+      - ../../../problems:/problems                                    # LQDOJ/problems
+    ports:
+      - "8001:8001"
+    depends_on:
+      db:
+        condition: service_healthy
+      memcached:
+        condition: service_started
+      redis:
+        condition: service_started
+
+volumes:
+  db_data:

--- a/.docker/dev-local/docker-entrypoint.sh
+++ b/.docker/dev-local/docker-entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -e
+
+echo "==> Compiling SCSS (Step 6: make_style.sh)"
+cd /code
+sass resources:sass_processed --no-source-map --style=expanded --quiet
+postcss \
+    sass_processed/style.css \
+    sass_processed/content-description.css \
+    sass_processed/table.css \
+    sass_processed/ranks.css \
+    --use autoprefixer -d resources --no-map
+echo "    SCSS done."
+
+echo "==> Collecting static files"
+python3 manage.py collectstatic --noinput -v 0
+
+echo "==> Compiling translations"
+python3 manage.py compilemessages -v 0 2>/dev/null || true
+python3 manage.py compilejsi18n -v 0 2>/dev/null || true
+
+echo "==> Running migrations"
+python3 manage.py migrate --noinput -v 0
+
+# Load initial fixtures on first run (detect via empty navbar table)
+echo "==> Checking initial data..."
+NAVBAR_COUNT=$(python3 manage.py shell -c "from judge.models import NavigationBar; print(NavigationBar.objects.count())" 2>/dev/null || echo "0")
+if [ "$NAVBAR_COUNT" = "0" ]; then
+    echo "    Loading initial fixtures (navbar, languages)..."
+    python3 manage.py loaddata navbar -v 0
+    python3 manage.py loaddata language_small -v 0
+    echo "    Done. Run 'docker compose run --rm web python3 manage.py createsuperuser' to create an admin user."
+fi
+
+echo "==> Starting server..."
+exec "$@"

--- a/.docker/dev-local/local_settings_docker.py
+++ b/.docker/dev-local/local_settings_docker.py
@@ -1,0 +1,53 @@
+# Docker-specific settings — mounted over local_settings.py inside the container.
+# Uses the real mysqlclient driver (installed via libmysqlclient-dev), no pymysql shim needed.
+
+SECRET_KEY = "lqdoj-docker-dev-key-not-for-production"
+
+DEBUG = True
+ALLOWED_HOSTS = ["*"]
+
+# ── Database ─────────────────────────────────────────────────────────────────
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.mysql",
+        "NAME": "dmoj",
+        "USER": "dmoj",
+        "PASSWORD": "dmoj",
+        "HOST": "db",
+        "PORT": "3306",
+        "OPTIONS": {
+            "charset": "utf8mb4",
+            "sql_mode": "STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION",
+        },
+    }
+}
+
+# ── Cache (memcached) ────────────────────────────────────────────────────────
+CACHES = {
+    "default": {
+        "BACKEND": "judge.cache_handler.CacheHandler",
+    },
+    "primary": {
+        "BACKEND": "django.core.cache.backends.memcached.PyMemcacheCache",
+        "LOCATION": "memcached:11211",
+    },
+}
+
+# ── Celery / Redis ───────────────────────────────────────────────────────────
+CELERY_BROKER_URL_SECRET = "redis://redis:6379"
+CELERY_RESULT_BACKEND_SECRET = "redis://redis:6379"
+
+# ── Static / Media / Problems ────────────────────────────────────────────────
+STATIC_ROOT = "/static"
+MEDIA_ROOT = "/media"
+DMOJ_PROBLEM_DATA_ROOT = "/problems"
+
+# ── Site identity ────────────────────────────────────────────────────────────
+SITE_NAME = "LQDOJ"
+SITE_LONG_NAME = "Le Quy Don Online Judge"
+
+# ── Chat (required) ──────────────────────────────────────────────────────────
+CHAT_SECRET_KEY = "ey7AAB1E6_14AMGUNY6yIKM05wWx9dTE9N0naq4Hr58="
+
+# ── Event daemon (disabled for basic dev) ───────────────────────────────────
+EVENT_DAEMON_SUBMISSION_KEY = "docker-dev-submission-key"

--- a/.docker/dev-local/local_settings_docker.py
+++ b/.docker/dev-local/local_settings_docker.py
@@ -51,3 +51,13 @@ CHAT_SECRET_KEY = "ey7AAB1E6_14AMGUNY6yIKM05wWx9dTE9N0naq4Hr58="
 
 # ── Event daemon (disabled for basic dev) ───────────────────────────────────
 EVENT_DAEMON_SUBMISSION_KEY = "docker-dev-submission-key"
+
+# ── Bridge (judge ↔ Django) ──────────────────────────────────────────────────
+# Bridge listens on 0.0.0.0 so both web and judge containers can reach it.
+# Web container connects to bridge by Docker Compose service name.
+BRIDGED_JUDGE_ADDRESS = [("0.0.0.0", 9999)]  # judges connect here
+BRIDGED_DJANGO_ADDRESS = [("0.0.0.0", 9998)]  # web connects here
+BRIDGED_DJANGO_CONNECT = (
+    "bridge",
+    9998,
+)  # web → bridge hostname (must be a single tuple)

--- a/.docker/dev-local/mariadb-init/01-timezone.sh
+++ b/.docker/dev-local/mariadb-init/01-timezone.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Load timezone data into mysql DB (README Step 3: mariadb-tzinfo-to-sql)
+# This runs inside the MariaDB container on first start.
+mariadb-tzinfo-to-sql /usr/share/zoneinfo | mariadb -u root -p"$MYSQL_ROOT_PASSWORD" mysql

--- a/judge/cache_handler.py
+++ b/judge/cache_handler.py
@@ -6,7 +6,11 @@ import time
 import sys
 
 DEFAULT_L0_TIMEOUT = 60
-primary_cache = caches["primary"] if "primary" in caches else None
+
+
+def _primary_cache():
+    return caches["primary"] if "primary" in caches else None
+
 
 # Thread-local storage for request-scoped L0 cache
 _thread_local = threading.local()
@@ -431,7 +435,7 @@ class CacheHandler(BaseCache):
         if stats_config["track_primary"] and l0_cache.stats:
             start_time = time.perf_counter()
             try:
-                result = primary_cache.get(key, **kwargs)
+                result = _primary_cache().get(key, **kwargs)
                 duration = time.perf_counter() - start_time
 
                 if result is not None:
@@ -446,7 +450,7 @@ class CacheHandler(BaseCache):
                 return default
         else:
             # Original behavior when stats are disabled
-            result = primary_cache.get(key, **kwargs)
+            result = _primary_cache().get(key, **kwargs)
             if result is not None:
                 l0_cache.set(key, result)
                 return result
@@ -464,7 +468,7 @@ class CacheHandler(BaseCache):
         if stats_config["track_primary"] and l0_cache.stats:
             start_time = time.perf_counter()
             try:
-                primary_cache.set(key, value, timeout, **kwargs)
+                _primary_cache().set(key, value, timeout, **kwargs)
                 duration = time.perf_counter() - start_time
                 l0_cache.stats.record_primary_set(duration)
             except Exception:
@@ -472,7 +476,7 @@ class CacheHandler(BaseCache):
                 raise  # Re-raise since set operations should fail if primary cache fails
         else:
             # Original behavior when stats are disabled
-            primary_cache.set(key, value, timeout, **kwargs)
+            _primary_cache().set(key, value, timeout, **kwargs)
 
     def delete(self, key, **kwargs):
         """
@@ -485,14 +489,14 @@ class CacheHandler(BaseCache):
         stats_config = _get_cache_stats_config()
         if stats_config["track_primary"] and l0_cache.stats:
             try:
-                primary_cache.delete(key, **kwargs)
+                _primary_cache().delete(key, **kwargs)
                 l0_cache.stats.record_primary_delete()
             except Exception:
                 l0_cache.stats.record_primary_error()
                 raise  # Re-raise since delete operations should fail if primary cache fails
         else:
             # Original behavior when stats are disabled
-            primary_cache.delete(key, **kwargs)
+            _primary_cache().delete(key, **kwargs)
 
     def add(self, key, value, timeout=None, **kwargs):
         """
@@ -507,7 +511,7 @@ class CacheHandler(BaseCache):
         if stats_config["track_primary"] and l0_cache.stats:
             start_time = time.perf_counter()
             try:
-                result = primary_cache.add(key, value, timeout, **kwargs)
+                result = _primary_cache().add(key, value, timeout, **kwargs)
                 duration = time.perf_counter() - start_time
                 l0_cache.stats.record_primary_set(duration)
                 return result
@@ -516,7 +520,7 @@ class CacheHandler(BaseCache):
                 raise  # Re-raise since add operations should fail if primary cache fails
         else:
             # Original behavior when stats are disabled
-            return primary_cache.add(key, value, timeout, **kwargs)
+            return _primary_cache().add(key, value, timeout, **kwargs)
 
     def get_many(self, keys, **kwargs):
         """
@@ -543,7 +547,7 @@ class CacheHandler(BaseCache):
         if stats_config["track_primary"] and l0_cache.stats:
             start_time = time.perf_counter()
             try:
-                cache_results = primary_cache.get_many(remaining_keys, **kwargs)
+                cache_results = _primary_cache().get_many(remaining_keys, **kwargs)
                 duration = time.perf_counter() - start_time
 
                 # Record hits and misses for each key
@@ -568,7 +572,7 @@ class CacheHandler(BaseCache):
                 return results
         else:
             # Original behavior when stats are disabled
-            cache_results = primary_cache.get_many(remaining_keys, **kwargs)
+            cache_results = _primary_cache().get_many(remaining_keys, **kwargs)
             if cache_results:
                 # Update L0 cache with results from primary cache
                 for key, value in cache_results.items():
@@ -589,7 +593,7 @@ class CacheHandler(BaseCache):
         if stats_config["track_primary"] and l0_cache.stats:
             start_time = time.perf_counter()
             try:
-                primary_cache.set_many(data, timeout, **kwargs)
+                _primary_cache().set_many(data, timeout, **kwargs)
                 duration = time.perf_counter() - start_time
                 for _ in data:
                     l0_cache.stats.record_primary_set(duration / len(data))
@@ -597,7 +601,7 @@ class CacheHandler(BaseCache):
                 l0_cache.stats.record_primary_error()
                 raise
         else:
-            primary_cache.set_many(data, timeout, **kwargs)
+            _primary_cache().set_many(data, timeout, **kwargs)
 
     def delete_many(self, keys, **kwargs):
         """
@@ -610,14 +614,14 @@ class CacheHandler(BaseCache):
         stats_config = _get_cache_stats_config()
         if stats_config["track_primary"] and l0_cache.stats:
             try:
-                primary_cache.delete_many(keys, **kwargs)
+                _primary_cache().delete_many(keys, **kwargs)
                 for _ in keys:
                     l0_cache.stats.record_primary_delete()
             except Exception:
                 l0_cache.stats.record_primary_error()
                 raise
         else:
-            primary_cache.delete_many(keys, **kwargs)
+            _primary_cache().delete_many(keys, **kwargs)
 
     def clear(self, **kwargs):
         """
@@ -629,13 +633,13 @@ class CacheHandler(BaseCache):
         stats_config = _get_cache_stats_config()
         if stats_config["track_primary"] and l0_cache.stats:
             try:
-                primary_cache.clear(**kwargs)
+                _primary_cache().clear(**kwargs)
                 l0_cache.stats.record_primary_delete()
             except Exception:
                 l0_cache.stats.record_primary_error()
                 raise
         else:
-            primary_cache.clear(**kwargs)
+            _primary_cache().clear(**kwargs)
 
     def incr(self, key, delta=1, **kwargs):
         """
@@ -647,7 +651,7 @@ class CacheHandler(BaseCache):
         if stats_config["track_primary"] and l0_cache.stats:
             start_time = time.perf_counter()
             try:
-                result = primary_cache.incr(key, delta, **kwargs)
+                result = _primary_cache().incr(key, delta, **kwargs)
                 duration = time.perf_counter() - start_time
                 l0_cache.stats.record_primary_set(
                     duration
@@ -658,7 +662,7 @@ class CacheHandler(BaseCache):
                 l0_cache.stats.record_primary_error()
                 raise
         else:
-            result = primary_cache.incr(key, delta, **kwargs)
+            result = _primary_cache().incr(key, delta, **kwargs)
             l0_cache.set(key, result)
             return result
 
@@ -672,7 +676,7 @@ class CacheHandler(BaseCache):
         if stats_config["track_primary"] and l0_cache.stats:
             start_time = time.perf_counter()
             try:
-                result = primary_cache.decr(key, delta, **kwargs)
+                result = _primary_cache().decr(key, delta, **kwargs)
                 duration = time.perf_counter() - start_time
                 l0_cache.stats.record_primary_set(
                     duration
@@ -683,6 +687,6 @@ class CacheHandler(BaseCache):
                 l0_cache.stats.record_primary_error()
                 raise
         else:
-            result = primary_cache.decr(key, delta, **kwargs)
+            result = _primary_cache().decr(key, delta, **kwargs)
             l0_cache.set(key, result)
             return result

--- a/judge/management/commands/seed_dev_data.py
+++ b/judge/management/commands/seed_dev_data.py
@@ -1,0 +1,748 @@
+"""
+python3 manage.py seed_dev_data [--clear] [--seed N]
+
+PCT-based seeder: all data generated procedurally from config tables.
+
+Creates:
+  - 1 admin superuser  (admin / devpass123)
+  - 60 regular users   (password: devpass123)
+  - 5 organizations
+  - 210 problems across 10 categories
+  - 14 blog posts
+  - 27 contests  (past rated, past unrated, live, upcoming)
+  - ~4 000–6 000 submissions with realistic per-tier distributions
+"""
+
+import random
+from datetime import timedelta
+
+from django.contrib.auth.models import User
+from django.core.management.base import BaseCommand
+from django.db.models import Max
+from django.utils import timezone
+
+# ── Config tables ─────────────────────────────────────────────────────────────
+
+_LANGUAGE_DEFS = [
+    dict(
+        key="CPP17",
+        name="C++17",
+        short_name="C++17",
+        common_name="C++",
+        ace="c_cpp",
+        pygments="cpp",
+        extension="cpp",
+    ),
+    dict(
+        key="CPP14",
+        name="C++14",
+        short_name="C++14",
+        common_name="C++",
+        ace="c_cpp",
+        pygments="cpp",
+        extension="cpp",
+    ),
+    dict(
+        key="PY3",
+        name="Python 3",
+        short_name="PY3",
+        common_name="Python",
+        ace="python",
+        pygments="python3",
+        extension="py",
+    ),
+    dict(
+        key="JAVA",
+        name="Java",
+        short_name="Java",
+        common_name="Java",
+        ace="java",
+        pygments="java",
+        extension="java",
+    ),
+    dict(
+        key="PAS",
+        name="Pascal",
+        short_name="Pascal",
+        common_name="Pascal",
+        ace="pascal",
+        pygments="delphi",
+        extension="pas",
+    ),
+]
+
+# (tier, count, rating_lo, rating_hi, lang_key, max_difficulty, ac_base_prob)
+_SKILL_TIERS = [
+    ("grandmaster", 5, 2200, 2800, "CPP17", 100, 0.88),
+    ("master", 8, 1900, 2199, "CPP17", 85, 0.72),
+    ("expert", 12, 1600, 1899, "CPP17", 70, 0.58),
+    ("specialist", 15, 1200, 1599, "CPP14", 52, 0.38),
+    ("pupil", 10, 900, 1199, "PY3", 36, 0.22),
+    ("newbie", 10, 100, 899, "PY3", 22, 0.10),
+]
+
+# slug, name, short_name, is_open
+_ORG_DEFS = [
+    ("lqdoj-staff", "LQDOJ Staff", "Staff", False),
+    ("algo-club", "Algorithm Club", "AlgoClub", True),
+    ("icpc-vn", "ICPC Vietnam", "ICPC", False),
+    ("beginners", "Beginners Circle", "Beginners", True),
+    ("adv-setters", "Advanced Problem Setters", "APS", False),
+]
+
+# prefix, display_name, group_idx(0=beg 1=int 2=adv), diff_min, diff_max, pts_min, pts_max, time_limit, count
+_PROB_CATS = [
+    ("impl", "Implementation", 0, 5, 28, 1, 12, 1.0, 20),
+    ("math", "Mathematics", 0, 5, 38, 1, 18, 1.0, 20),
+    ("sort", "Sorting", 0, 5, 24, 1, 8, 1.0, 20),
+    ("bs", "Binary Search", 1, 14, 52, 8, 22, 1.0, 20),
+    ("greedy", "Greedy", 1, 18, 62, 12, 28, 2.0, 20),
+    ("dp", "Dynamic Prog.", 1, 24, 72, 18, 38, 2.0, 25),
+    ("graph", "Graph Theory", 2, 28, 82, 22, 48, 2.0, 25),
+    ("str", "Strings", 2, 24, 72, 18, 38, 2.0, 20),
+    ("ds", "Data Structures", 2, 32, 88, 28, 58, 2.0, 20),
+    ("adv", "Advanced", 2, 48, 99, 38, 99, 3.0, 20),
+]
+# Total: 20*8 + 25*2 = 210 problems
+
+_BLOG_TITLES = [
+    ("Welcome to LQDOJ Dev Environment", True, 30),
+    ("Announcement: System Maintenance", False, 25),
+    ("Editorial: LQDOJ Round #1", False, 20),
+    ("Tips for Competitive Programming", True, 18),
+    ("Editorial: LQDOJ Round #2", False, 15),
+    ("New Problems Added — March 2026", False, 12),
+    ("Contest Schedule — April 2026", True, 10),
+    ("Editorial: LQDOJ Round #3", False, 8),
+    ("How to use the judge effectively", False, 6),
+    ("Results: Beginner Contest #3", False, 4),
+    ("Upcoming: ICPC Warmup Series", True, 3),
+    ("Problem Pack: Graph Theory", False, 2),
+    ("Problem Pack: Dynamic Programming", False, 1),
+    ("Leaderboard Update — April 2026", False, 0),
+]
+
+_TIMEZONES = ["Asia/Ho_Chi_Minh", "Asia/Bangkok", "Asia/Singapore", "UTC", "Asia/Tokyo"]
+
+_SYLLABLES = [
+    "minh",
+    "anh",
+    "tuan",
+    "linh",
+    "huy",
+    "nam",
+    "khoa",
+    "long",
+    "dung",
+    "trang",
+    "hoa",
+    "duc",
+    "bao",
+    "cuong",
+    "dat",
+    "hai",
+    "hung",
+    "lan",
+    "mai",
+    "phuong",
+    "quang",
+    "son",
+    "thanh",
+    "thao",
+    "thu",
+    "tien",
+    "toan",
+    "trung",
+    "van",
+    "viet",
+    "yen",
+    "ky",
+    "lam",
+    "loc",
+    "my",
+    "ngoc",
+    "nhat",
+    "phat",
+    "phuc",
+    "sang",
+    "tai",
+    "tam",
+    "thien",
+    "thinh",
+    "trong",
+    "tung",
+    "uyen",
+    "vu",
+    "xuan",
+    "bich",
+]
+
+# ── Source snippets ───────────────────────────────────────────────────────────
+
+_SRC = {
+    "AC_CPP": "#include<bits/stdc++.h>\nusing namespace std;\nint main(){int a,b;cin>>a>>b;cout<<a+b;}",
+    "AC_PY": "a,b=map(int,input().split())\nprint(a+b)",
+    "WA": "#include<bits/stdc++.h>\nusing namespace std;\nint main(){cout<<42;}",
+    "TLE": "int main(){while(1);}",
+    "CE": "this is not valid C++",
+    "MLE": "#include<bits/stdc++.h>\nusing namespace std;\nint main(){vector<int>v(1<<28);cout<<v[0];}",
+    "RTE": "#include<bits/stdc++.h>\nusing namespace std;\nint main(){int*p=0;*p=1;}",
+}
+
+
+def _src_for(result, lang_key):
+    if result == "AC":
+        return _SRC["AC_PY"] if lang_key == "PY3" else _SRC["AC_CPP"]
+    return _SRC.get(result, _SRC["WA"])
+
+
+class Command(BaseCommand):
+    help = "Seed the development database with PCT-generated sample data"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--clear",
+            action="store_true",
+            help="Delete all seeded objects before re-creating.",
+        )
+        parser.add_argument(
+            "--seed", type=int, default=42, help="Random seed (default 42)."
+        )
+
+    def handle(self, *args, **options):
+        random.seed(options["seed"])
+
+        if options["clear"]:
+            self._clear()
+
+        self._seed_languages()
+        self._seed_admin()
+        user_tier_map = self._seed_users()  # profile -> tier_dict
+        profiles = list(user_tier_map.keys())
+        self._seed_organizations(profiles)
+        prob_diff_map = self._seed_problems(profiles)  # problem -> difficulty int
+        self._seed_blog_posts(profiles)
+        self._seed_contests(profiles, prob_diff_map)
+        self._seed_submissions(user_tier_map, prob_diff_map)
+        self._update_user_points(profiles)
+
+        self.stdout.write(self.style.SUCCESS("\n✓ Dev seed complete."))
+        self.stdout.write("  admin / devpass123  (superuser)")
+        self.stdout.write("  60 dev users        (password: devpass123)")
+        self.stdout.write("  http://localhost:8001/accounts/login/")
+
+    # ── Clear ─────────────────────────────────────────────────────────────────
+
+    def _clear(self):
+        from judge.models import BlogPost, Contest, Organization, Problem, Submission
+
+        self.stdout.write(self.style.WARNING("Clearing seeded data…"))
+        Submission.objects.filter(user__user__username__startswith="dev_").delete()
+        Contest.objects.filter(key__startswith="dev_").delete()
+        Problem.objects.filter(code__startswith="dev_").delete()
+        BlogPost.objects.filter(summary="[dev-seed]").delete()
+        for slug, *_ in _ORG_DEFS:
+            Organization.objects.filter(slug=slug).delete()
+        User.objects.filter(username__startswith="dev_").delete()
+        self.stdout.write("  Done.")
+
+    # ── Languages ─────────────────────────────────────────────────────────────
+
+    def _seed_languages(self):
+        from judge.models import Language
+
+        self.stdout.write("\n── Languages")
+        for spec in _LANGUAGE_DEFS:
+            key = spec["key"]
+            _, created = Language.objects.get_or_create(
+                key=key, defaults={k: v for k, v in spec.items() if k != "key"}
+            )
+            self.stdout.write(f"  {'created' if created else 'exists '} {key}")
+
+    # ── Admin ─────────────────────────────────────────────────────────────────
+
+    def _seed_admin(self):
+        from judge.models import Profile
+
+        self.stdout.write("\n── Admin account")
+        if not User.objects.filter(username="admin").exists():
+            admin = User.objects.create_superuser(
+                "admin", "admin@dev.local", "devpass123"
+            )
+            Profile.objects.get_or_create(user=admin)
+            self.stdout.write("  created  admin (password: devpass123, superuser=True)")
+        else:
+            self.stdout.write("  exists   admin")
+
+    # ── Users ─────────────────────────────────────────────────────────────────
+
+    def _seed_users(self):
+        from judge.models import Language, Profile
+
+        self.stdout.write("\n── Users")
+
+        lang_cache = {
+            spec["key"]: Language.objects.filter(key=spec["key"]).first()
+            for spec in _LANGUAGE_DEFS
+        }
+        used = set(User.objects.values_list("username", flat=True))
+        user_tier_map = {}
+        total_created = 0
+
+        for (
+            tier,
+            count,
+            rating_lo,
+            rating_hi,
+            lang_key,
+            max_diff,
+            ac_base,
+        ) in _SKILL_TIERS:
+            lang = lang_cache.get(lang_key)
+            created_in_tier = 0
+
+            for _ in range(count):
+                # Generate a unique username
+                for attempt in range(100):
+                    syl = random.choice(_SYLLABLES)
+                    num = random.randint(10, 999)
+                    username = f"dev_{syl}{num}"
+                    if username not in used:
+                        used.add(username)
+                        break
+                else:
+                    username = f"dev_user{len(used)}"
+                    used.add(username)
+
+                user, created = User.objects.get_or_create(
+                    username=username,
+                    defaults=dict(
+                        first_name=syl.title(),
+                        email=f"{username}@dev.local",
+                        is_staff=False,
+                    ),
+                )
+                if created:
+                    user.set_password("devpass123")
+                    user.save()
+                    created_in_tier += 1
+
+                profile, _ = Profile.objects.get_or_create(user=user)
+                profile.timezone = random.choice(_TIMEZONES)
+                profile.rating = random.randint(rating_lo, rating_hi)
+                profile.points = 0.0
+                if lang:
+                    profile.language = lang
+                profile.save()
+
+                user_tier_map[profile] = {
+                    "tier": tier,
+                    "lang_key": lang_key,
+                    "lang": lang,
+                    "max_diff": max_diff,
+                    "ac_base": ac_base,
+                }
+
+            total_created += created_in_tier
+            self.stdout.write(f"  {tier:14s}  {count} slots  {created_in_tier} new")
+
+        self.stdout.write(f"  total: {len(user_tier_map)} users ({total_created} new)")
+        return user_tier_map
+
+    # ── Organizations ─────────────────────────────────────────────────────────
+
+    def _seed_organizations(self, profiles):
+        from judge.models import Organization
+
+        self.stdout.write("\n── Organizations")
+
+        for idx, (slug, name, short, is_open) in enumerate(_ORG_DEFS):
+            admin = profiles[idx % len(profiles)]
+            org, created = Organization.objects.get_or_create(
+                slug=slug,
+                defaults=dict(
+                    name=name,
+                    short_name=short,
+                    about="",
+                    is_open=is_open,
+                    registrant=admin,
+                ),
+            )
+            if created:
+                org.admins.set([admin])
+                members = random.sample(
+                    profiles, max(1, int(len(profiles) * random.uniform(0.3, 0.6)))
+                )
+                org.members.add(*members)
+            self.stdout.write(f"  {'created' if created else 'exists '} {slug}")
+
+    # ── Problems ──────────────────────────────────────────────────────────────
+
+    def _seed_problems(self, profiles):
+        from judge.models import Problem, ProblemGroup, ProblemType
+
+        self.stdout.write("\n── Problem types / groups / problems")
+
+        # Problem types (one per category display name)
+        type_objs = {}
+        for _, display, *_ in _PROB_CATS:
+            t, _ = ProblemType.objects.get_or_create(name=display)
+            type_objs[display] = t
+
+        groups = []
+        for g in ["Beginner", "Intermediate", "Advanced"]:
+            obj, _ = ProblemGroup.objects.get_or_create(name=g)
+            groups.append(obj)
+
+        # Use first 8 profiles as potential authors
+        author_pool = profiles[:8]
+        prob_diff_map = {}
+        total = 0
+
+        for (
+            prefix,
+            display,
+            grp_idx,
+            diff_min,
+            diff_max,
+            pts_min,
+            pts_max,
+            tl,
+            count,
+        ) in _PROB_CATS:
+            ptype = type_objs[display]
+            group = groups[grp_idx]
+            ml_choices = [65536, 131072, 262144]
+
+            for i in range(1, count + 1):
+                code = f"dev_{prefix}_{i:02d}"
+                diff = random.randint(diff_min, diff_max)
+                pts = random.randint(pts_min, pts_max)
+                ml = random.choice(ml_choices)
+
+                p, created = Problem.objects.get_or_create(
+                    code=code,
+                    defaults=dict(
+                        name=f"{display} #{i}",
+                        time_limit=float(tl),
+                        memory_limit=ml,
+                        points=float(pts),
+                        group=group,
+                        is_public=True,
+                        short_circuit=False,
+                        partial=False,
+                        description=(
+                            f"## {display} #{i}\n\n"
+                            f"Solve this problem.\n\n"
+                            f"**Difficulty:** {diff}/100\n\n"
+                            f"### Input\nDescribed in the problem statement.\n\n"
+                            f"### Output\nDescribed in the problem statement."
+                        ),
+                    ),
+                )
+                if created and author_pool:
+                    p.types.set([ptype])
+                    p.authors.set(
+                        random.sample(
+                            author_pool, random.randint(1, min(2, len(author_pool)))
+                        )
+                    )
+
+                prob_diff_map[p] = diff
+                total += 1
+
+        self.stdout.write(
+            f"  {total} problems  ({sum(c for *_, c in _PROB_CATS)} expected)"
+        )
+        return prob_diff_map
+
+    # ── Blog posts ────────────────────────────────────────────────────────────
+
+    def _seed_blog_posts(self, profiles):
+        from judge.models import BlogPost
+
+        self.stdout.write("\n── Blog posts")
+        now = timezone.now()
+        count = 0
+
+        for title, sticky, days_ago in _BLOG_TITLES:
+            author = random.choice(profiles)
+            post, created = BlogPost.objects.get_or_create(
+                title=title,
+                defaults=dict(
+                    content=f"## {title}\n\nContent for this post.",
+                    summary="[dev-seed]",
+                    visible=True,
+                    sticky=sticky,
+                    publish_on=now - timedelta(days=days_ago),
+                ),
+            )
+            if created:
+                post.authors.set([author])
+                count += 1
+
+        self.stdout.write(f"  {count} new posts  ({len(_BLOG_TITLES)} total)")
+
+    # ── Contests ──────────────────────────────────────────────────────────────
+
+    def _seed_contests(self, profiles, prob_diff_map):
+        from judge.models import Contest, ContestProblem
+
+        self.stdout.write("\n── Contests")
+
+        now = timezone.now()
+        problems = list(prob_diff_map.keys())
+
+        # Split problem pool by code prefix for difficulty-aware picking
+        def pool(*prefixes):
+            return [
+                p
+                for p in problems
+                if any(p.code.startswith(f"dev_{pfx}_") for pfx in prefixes)
+            ]
+
+        easy = pool("impl", "math", "sort")
+        medium = pool("bs", "greedy", "dp", "str")
+        hard = pool("graph", "ds", "adv")
+
+        def pick(n_easy, n_med, n_hard):
+            return (
+                random.sample(easy, min(n_easy, len(easy)))
+                + random.sample(medium, min(n_med, len(medium)))
+                + random.sample(hard, min(n_hard, len(hard)))
+            )
+
+        specs = []
+
+        # 10 past rated rounds (weekly, ending ~2 hours before end)
+        for n in range(1, 11):
+            specs.append(
+                dict(
+                    key=f"dev_round{n:02d}",
+                    name=f"LQDOJ Round #{n}",
+                    start=now - timedelta(days=n * 7 + 2, hours=14),
+                    end=now - timedelta(days=n * 7 + 2, hours=10),
+                    rated=True,
+                    probs=pick(1, 2, 3),
+                )
+            )
+
+        # 6 past unrated weekly practice sessions
+        for n in range(1, 7):
+            specs.append(
+                dict(
+                    key=f"dev_practice{n:02d}",
+                    name=f"Weekly Practice #{n}",
+                    start=now - timedelta(days=n * 7 + 1, hours=20),
+                    end=now - timedelta(days=n * 7 + 1, hours=17),
+                    rated=False,
+                    probs=pick(2, 2, 1),
+                )
+            )
+
+        # 5 past beginner-only contests
+        for n in range(1, 6):
+            specs.append(
+                dict(
+                    key=f"dev_beg{n:02d}",
+                    name=f"Beginner Contest #{n}",
+                    start=now - timedelta(days=n * 14 + 3, hours=15),
+                    end=now - timedelta(days=n * 14 + 3, hours=13),
+                    rated=True,
+                    probs=pick(3, 1, 0),
+                )
+            )
+
+        # 2 currently live
+        specs.append(
+            dict(
+                key="dev_live01",
+                name="LQDOJ Live Contest",
+                start=now - timedelta(hours=1),
+                end=now + timedelta(hours=3),
+                rated=False,
+                probs=pick(1, 2, 2),
+            )
+        )
+        specs.append(
+            dict(
+                key="dev_live02",
+                name="Advanced Training Session",
+                start=now - timedelta(hours=2),
+                end=now + timedelta(hours=2),
+                rated=False,
+                probs=pick(0, 2, 3),
+            )
+        )
+
+        # 4 upcoming rounds
+        for n in range(1, 5):
+            specs.append(
+                dict(
+                    key=f"dev_upcoming{n:02d}",
+                    name=f"LQDOJ Round #{n + 10}",
+                    start=now + timedelta(days=n * 7 - 3, hours=14),
+                    end=now + timedelta(days=n * 7 - 3, hours=18),
+                    rated=True,
+                    probs=pick(1, 2, 3),
+                )
+            )
+
+        count = 0
+        for s in specs:
+            c, created = Contest.objects.get_or_create(
+                key=s["key"],
+                defaults=dict(
+                    name=s["name"],
+                    start_time=s["start"],
+                    end_time=s["end"],
+                    time_limit=None,
+                    is_visible=True,
+                    is_rated=s["rated"],
+                    format_name="default",
+                    scoreboard_visibility=Contest.SCOREBOARD_VISIBLE,
+                    description=f"Welcome to **{s['name']}**!",
+                ),
+            )
+            if created:
+                c.authors.set([random.choice(profiles)])
+                c.curators.set(random.sample(profiles, min(2, len(profiles))))
+                for order, prob in enumerate(s["probs"], 1):
+                    ContestProblem.objects.get_or_create(
+                        contest=c,
+                        problem=prob,
+                        defaults=dict(points=prob.points, order=order),
+                    )
+                count += 1
+
+        self.stdout.write(f"  {count} new contests  ({len(specs)} total)")
+
+    # ── Submissions ───────────────────────────────────────────────────────────
+
+    def _seed_submissions(self, user_tier_map, prob_diff_map):
+        from judge.models import Language, Submission
+
+        self.stdout.write("\n── Submissions  (this may take a moment…)")
+
+        lang_cache = {
+            spec["key"]: Language.objects.filter(key=spec["key"]).first()
+            for spec in _LANGUAGE_DEFS
+        }
+        cpp = lang_cache.get("CPP17") or lang_cache.get("CPP14")
+        now = timezone.now()
+        total = 0
+
+        for profile, tier in user_tier_map.items():
+            max_diff = tier["max_diff"]
+            ac_base = tier["ac_base"]
+            lang_key = tier["lang_key"]
+            lang = tier["lang"]
+
+            # Problems within this user's difficulty reach
+            reachable = [(p, d) for p, d in prob_diff_map.items() if d <= max_diff]
+            # Attempt 50–75 % of reachable problems
+            n_attempt = max(1, int(len(reachable) * random.uniform(0.50, 0.75)))
+            to_attempt = random.sample(reachable, n_attempt)
+
+            for problem, difficulty in to_attempt:
+                # Skip if already seeded for this (user, problem)
+                if Submission.objects.filter(user=profile, problem=problem).exists():
+                    continue
+
+                # Difficulty-adjusted AC probability
+                diff_penalty = (difficulty / 100.0) * 0.40
+                ac_prob = max(0.02, ac_base - diff_penalty)
+                solves = random.random() < ac_prob
+
+                if solves:
+                    # 0 / 1 / 2 failed attempts before the AC
+                    n_failed = random.choices([0, 1, 2], weights=[60, 30, 10])[0]
+                    for _ in range(n_failed):
+                        fail = random.choices(
+                            ["WA", "TLE", "CE"], weights=[55, 30, 15]
+                        )[0]
+                        total += self._make_sub(
+                            profile, problem, fail, lang, lang_key, cpp, now
+                        )
+                    total += self._make_sub(
+                        profile, problem, "AC", lang, lang_key, cpp, now
+                    )
+                else:
+                    # 1–3 failed attempts, no AC
+                    n_fail = random.choices([1, 2, 3], weights=[50, 35, 15])[0]
+                    for _ in range(n_fail):
+                        fail = random.choices(
+                            ["WA", "TLE", "CE", "MLE", "RTE"],
+                            weights=[45, 25, 15, 10, 5],
+                        )[0]
+                        total += self._make_sub(
+                            profile, problem, fail, lang, lang_key, cpp, now
+                        )
+
+        self.stdout.write(f"  {total} submissions created")
+
+    def _make_sub(self, profile, problem, result, lang, lang_key, cpp_lang, now):
+        from judge.models import Submission, SubmissionSource
+
+        if result == "CE":
+            exe_time, mem = None, None
+            sub_lang = cpp_lang or lang
+        elif result == "TLE":
+            exe_time = round(problem.time_limit + random.uniform(0.1, 1.0), 3)
+            mem = round(random.uniform(2048, problem.memory_limit * 0.5), 1)
+            sub_lang = cpp_lang or lang
+        elif result == "MLE":
+            exe_time = round(random.uniform(0.1, problem.time_limit * 0.5), 3)
+            mem = round(problem.memory_limit + random.uniform(512, 4096), 1)
+            sub_lang = cpp_lang or lang
+        else:
+            exe_time = round(random.uniform(0.01, problem.time_limit * 0.85), 3)
+            mem = round(random.uniform(2048, problem.memory_limit * 0.7), 1)
+            sub_lang = lang if result == "AC" else (cpp_lang or lang)
+
+        pts = float(problem.points) if result == "AC" else 0.0
+
+        sub = Submission.objects.create(
+            user=profile,
+            problem=problem,
+            language=sub_lang,
+            status="D",
+            result=result,
+            time=exe_time,
+            memory=mem,
+            points=pts,
+            case_points=pts,
+            case_total=float(problem.points),
+        )
+        # auto_now_add=True prevents setting date in create(), use update()
+        Submission.objects.filter(pk=sub.pk).update(
+            date=now
+            - timedelta(
+                days=random.randint(0, 90),
+                hours=random.randint(0, 23),
+                minutes=random.randint(0, 59),
+            )
+        )
+        SubmissionSource.objects.get_or_create(
+            submission=sub,
+            defaults=dict(source=_src_for(result, lang_key)),
+        )
+        return 1
+
+    # ── Recompute points ──────────────────────────────────────────────────────
+
+    def _update_user_points(self, profiles):
+        self.stdout.write("\n── Recomputing user points")
+        from judge.models import Submission
+
+        for profile in profiles:
+            best = (
+                Submission.objects.filter(user=profile, result="AC")
+                .values("problem_id")
+                .annotate(best=Max("points"))
+            )
+            total = sum(row["best"] or 0 for row in best)
+            profile.points = total
+            profile.save(update_fields=["points"])
+
+        self.stdout.write(f"  updated {len(profiles)} profiles")

--- a/judge/management/commands/seed_dev_data.py
+++ b/judge/management/commands/seed_dev_data.py
@@ -71,6 +71,19 @@ _LANGUAGE_DEFS = [
     ),
 ]
 
+# Allowed language keys for all seeded problems
+_PROBLEM_ALLOWED_LANG_KEYS = [
+    "C",
+    "C11",
+    "CPP14",
+    "CPP17",
+    "CPP20",
+    "JAVA",
+    "JAVA8",
+    "PAS",
+    "PY3",
+]
+
 # (tier, count, rating_lo, rating_hi, lang_key, max_difficulty, ac_base_prob)
 _SKILL_TIERS = [
     ("grandmaster", 5, 2200, 2800, "CPP17", 100, 0.88),
@@ -189,6 +202,13 @@ _SRC = {
     "RTE": "#include<bits/stdc++.h>\nusing namespace std;\nint main(){int*p=0;*p=1;}",
 }
 
+_CE_ERRORS = [
+    "solution.cpp:1:1: error: 'this' is not valid C++\n  1 | this is not valid C++\n    | ^~~~",
+    "solution.cpp:1:8: error: expected ';' before 'is'\n  1 | this is not valid C++\n    |        ^~",
+    "solution.cpp:1:1: error: stray '#' in program\nnote: did you mean to use '#include'?",
+    "solution.cpp:3:5: error: 'mainn' was not declared in this scope\n  3 | int mainn() { return 0; }\n    |     ^~~~~",
+]
+
 
 def _src_for(result, lang_key):
     if result == "AC":
@@ -224,7 +244,8 @@ class Command(BaseCommand):
         self._seed_blog_posts(profiles)
         self._seed_contests(profiles, prob_diff_map)
         self._seed_submissions(user_tier_map, prob_diff_map)
-        self._update_user_points(profiles)
+        self._update_user_stats(profiles)
+        self._update_problem_stats(list(prob_diff_map.keys()))
 
         self.stdout.write(self.style.SUCCESS("\n✓ Dev seed complete."))
         self.stdout.write("  admin / devpass123  (superuser)")
@@ -269,7 +290,14 @@ class Command(BaseCommand):
             admin = User.objects.create_superuser(
                 "admin", "admin@dev.local", "devpass123"
             )
-            Profile.objects.get_or_create(user=admin)
+            Profile.objects.get_or_create(
+                user=admin,
+                defaults=dict(
+                    about="Site administrator.",
+                    timezone="Asia/Ho_Chi_Minh",
+                    display_rank="admin",
+                ),
+            )
             self.stdout.write("  created  admin (password: devpass123, superuser=True)")
         else:
             self.stdout.write("  exists   admin")
@@ -318,8 +346,10 @@ class Command(BaseCommand):
                     username=username,
                     defaults=dict(
                         first_name=syl.title(),
+                        last_name="Dev",
                         email=f"{username}@dev.local",
                         is_staff=False,
+                        is_active=True,
                     ),
                 )
                 if created:
@@ -327,10 +357,26 @@ class Command(BaseCommand):
                     user.save()
                     created_in_tier += 1
 
-                profile, _ = Profile.objects.get_or_create(user=user)
-                profile.timezone = random.choice(_TIMEZONES)
-                profile.rating = random.randint(rating_lo, rating_hi)
-                profile.points = 0.0
+                profile, _ = Profile.objects.get_or_create(
+                    user=user,
+                    defaults=dict(
+                        about=f"Competitive programmer — {tier} tier.",
+                        timezone=random.choice(_TIMEZONES),
+                        display_rank="user",
+                        rating=random.randint(rating_lo, rating_hi),
+                        points=0.0,
+                        performance_points=0.0,
+                        contribution_points=0,
+                        problem_count=0,
+                    ),
+                )
+                if not created:
+                    # Update mutable fields on existing profile
+                    profile.timezone = random.choice(_TIMEZONES)
+                    profile.rating = random.randint(rating_lo, rating_hi)
+                    profile.points = 0.0
+                    profile.problem_count = 0
+
                 if lang:
                     profile.language = lang
                 profile.save()
@@ -363,9 +409,10 @@ class Command(BaseCommand):
                 defaults=dict(
                     name=name,
                     short_name=short,
-                    about="",
+                    about=f"Official LQDOJ organization: {name}.",
                     is_open=is_open,
                     registrant=admin,
+                    is_community=False,
                 ),
             )
             if created:
@@ -379,7 +426,7 @@ class Command(BaseCommand):
     # ── Problems ──────────────────────────────────────────────────────────────
 
     def _seed_problems(self, profiles):
-        from judge.models import Problem, ProblemGroup, ProblemType
+        from judge.models import Language, Problem, ProblemGroup, ProblemType
 
         self.stdout.write("\n── Problem types / groups / problems")
 
@@ -394,10 +441,15 @@ class Command(BaseCommand):
             obj, _ = ProblemGroup.objects.get_or_create(name=g)
             groups.append(obj)
 
+        allowed_langs = list(
+            Language.objects.filter(key__in=_PROBLEM_ALLOWED_LANG_KEYS)
+        )
+
         # Use first 8 profiles as potential authors
         author_pool = profiles[:8]
         prob_diff_map = {}
         total = 0
+        now = timezone.now()
 
         for (
             prefix,
@@ -419,6 +471,7 @@ class Command(BaseCommand):
                 diff = random.randint(diff_min, diff_max)
                 pts = random.randint(pts_min, pts_max)
                 ml = random.choice(ml_choices)
+                pub_date = now - timedelta(days=random.randint(30, 365))
 
                 p, created = Problem.objects.get_or_create(
                     code=code,
@@ -431,6 +484,10 @@ class Command(BaseCommand):
                         is_public=True,
                         short_circuit=False,
                         partial=False,
+                        is_manually_managed=False,
+                        is_organization_private=False,
+                        date=pub_date,
+                        summary=f"A {display.lower()} problem.",
                         description=(
                             f"## {display} #{i}\n\n"
                             f"Solve this problem.\n\n"
@@ -438,15 +495,21 @@ class Command(BaseCommand):
                             f"### Input\nDescribed in the problem statement.\n\n"
                             f"### Output\nDescribed in the problem statement."
                         ),
+                        # Stats — will be recomputed after submissions
+                        user_count=0,
+                        ac_rate=0.0,
                     ),
                 )
-                if created and author_pool:
-                    p.types.set([ptype])
-                    p.authors.set(
-                        random.sample(
-                            author_pool, random.randint(1, min(2, len(author_pool)))
+                if created:
+                    if author_pool:
+                        p.types.set([ptype])
+                        p.authors.set(
+                            random.sample(
+                                author_pool, random.randint(1, min(2, len(author_pool)))
+                            )
                         )
-                    )
+                    if allowed_langs:
+                        p.allowed_languages.set(allowed_langs)
 
                 prob_diff_map[p] = diff
                 total += 1
@@ -486,7 +549,7 @@ class Command(BaseCommand):
     # ── Contests ──────────────────────────────────────────────────────────────
 
     def _seed_contests(self, profiles, prob_diff_map):
-        from judge.models import Contest, ContestProblem
+        from judge.models import Contest, ContestParticipation, ContestProblem
 
         self.stdout.write("\n── Contests")
 
@@ -523,6 +586,7 @@ class Command(BaseCommand):
                     start=now - timedelta(days=n * 7 + 2, hours=14),
                     end=now - timedelta(days=n * 7 + 2, hours=10),
                     rated=True,
+                    past=True,
                     probs=pick(1, 2, 3),
                 )
             )
@@ -536,6 +600,7 @@ class Command(BaseCommand):
                     start=now - timedelta(days=n * 7 + 1, hours=20),
                     end=now - timedelta(days=n * 7 + 1, hours=17),
                     rated=False,
+                    past=True,
                     probs=pick(2, 2, 1),
                 )
             )
@@ -549,6 +614,7 @@ class Command(BaseCommand):
                     start=now - timedelta(days=n * 14 + 3, hours=15),
                     end=now - timedelta(days=n * 14 + 3, hours=13),
                     rated=True,
+                    past=True,
                     probs=pick(3, 1, 0),
                 )
             )
@@ -561,6 +627,7 @@ class Command(BaseCommand):
                 start=now - timedelta(hours=1),
                 end=now + timedelta(hours=3),
                 rated=False,
+                past=False,
                 probs=pick(1, 2, 2),
             )
         )
@@ -571,6 +638,7 @@ class Command(BaseCommand):
                 start=now - timedelta(hours=2),
                 end=now + timedelta(hours=2),
                 rated=False,
+                past=False,
                 probs=pick(0, 2, 3),
             )
         )
@@ -584,6 +652,7 @@ class Command(BaseCommand):
                     start=now + timedelta(days=n * 7 - 3, hours=14),
                     end=now + timedelta(days=n * 7 - 3, hours=18),
                     rated=True,
+                    past=False,
                     probs=pick(1, 2, 3),
                 )
             )
@@ -599,9 +668,18 @@ class Command(BaseCommand):
                     time_limit=None,
                     is_visible=True,
                     is_rated=s["rated"],
+                    is_private=False,
+                    is_organization_private=False,
+                    use_clarifications=True,
+                    hide_problem_tags=False,
+                    run_pretests_only=False,
+                    public_scoreboard=True,
                     format_name="default",
                     scoreboard_visibility=Contest.SCOREBOARD_VISIBLE,
                     description=f"Welcome to **{s['name']}**!",
+                    summary=f"Dev-seeded contest: {s['name']}",
+                    user_count=0,
+                    points_precision=2,
                 ),
             )
             if created:
@@ -611,8 +689,40 @@ class Command(BaseCommand):
                     ContestProblem.objects.get_or_create(
                         contest=c,
                         problem=prob,
-                        defaults=dict(points=prob.points, order=order),
+                        defaults=dict(
+                            points=prob.points,
+                            order=order,
+                            max_submissions=0,
+                        ),
                     )
+
+                # Add participants for past contests
+                if s["past"]:
+                    n_participants = random.randint(
+                        max(5, len(profiles) // 4), len(profiles) // 2
+                    )
+                    participants = random.sample(profiles, n_participants)
+                    for participant in participants:
+                        # real_start: random time within contest window
+                        duration = s["end"] - s["start"]
+                        join_offset = timedelta(
+                            seconds=random.randint(
+                                0, int(duration.total_seconds() * 0.1)
+                            )
+                        )
+                        ContestParticipation.objects.get_or_create(
+                            contest=c,
+                            user=participant,
+                            virtual=ContestParticipation.LIVE,
+                            defaults=dict(
+                                real_start=s["start"] + join_offset,
+                                score=0.0,
+                                cumtime=0,
+                                is_disqualified=False,
+                                tiebreaker=0.0,
+                            ),
+                        )
+
                 count += 1
 
         self.stdout.write(f"  {count} new contests  ({len(specs)} total)")
@@ -620,7 +730,7 @@ class Command(BaseCommand):
     # ── Submissions ───────────────────────────────────────────────────────────
 
     def _seed_submissions(self, user_tier_map, prob_diff_map):
-        from judge.models import Language, Submission
+        from judge.models import Judge, Language, Submission
 
         self.stdout.write("\n── Submissions  (this may take a moment…)")
 
@@ -631,6 +741,9 @@ class Command(BaseCommand):
         cpp = lang_cache.get("CPP17") or lang_cache.get("CPP14")
         now = timezone.now()
         total = 0
+
+        # Fetch the dev judge for judged_on FK (may not exist yet in some envs)
+        dev_judge = Judge.objects.filter(name="judge1").first()
 
         for profile, tier in user_tier_map.items():
             max_diff = tier["max_diff"]
@@ -662,10 +775,10 @@ class Command(BaseCommand):
                             ["WA", "TLE", "CE"], weights=[55, 30, 15]
                         )[0]
                         total += self._make_sub(
-                            profile, problem, fail, lang, lang_key, cpp, now
+                            profile, problem, fail, lang, lang_key, cpp, now, dev_judge
                         )
                     total += self._make_sub(
-                        profile, problem, "AC", lang, lang_key, cpp, now
+                        profile, problem, "AC", lang, lang_key, cpp, now, dev_judge
                     )
                 else:
                     # 1–3 failed attempts, no AC
@@ -676,31 +789,55 @@ class Command(BaseCommand):
                             weights=[45, 25, 15, 10, 5],
                         )[0]
                         total += self._make_sub(
-                            profile, problem, fail, lang, lang_key, cpp, now
+                            profile, problem, fail, lang, lang_key, cpp, now, dev_judge
                         )
 
         self.stdout.write(f"  {total} submissions created")
 
-    def _make_sub(self, profile, problem, result, lang, lang_key, cpp_lang, now):
+    def _make_sub(
+        self, profile, problem, result, lang, lang_key, cpp_lang, now, dev_judge
+    ):
         from judge.models import Submission, SubmissionSource
 
         if result == "CE":
-            exe_time, mem = None, None
+            exe_time = None
+            mem = None
             sub_lang = cpp_lang or lang
+            error_text = random.choice(_CE_ERRORS)
         elif result == "TLE":
             exe_time = round(problem.time_limit + random.uniform(0.1, 1.0), 3)
             mem = round(random.uniform(2048, problem.memory_limit * 0.5), 1)
             sub_lang = cpp_lang or lang
+            error_text = None
         elif result == "MLE":
             exe_time = round(random.uniform(0.1, problem.time_limit * 0.5), 3)
             mem = round(problem.memory_limit + random.uniform(512, 4096), 1)
             sub_lang = cpp_lang or lang
+            error_text = None
+        elif result == "RTE":
+            exe_time = round(random.uniform(0.01, problem.time_limit * 0.5), 3)
+            mem = round(random.uniform(2048, problem.memory_limit * 0.4), 1)
+            sub_lang = cpp_lang or lang
+            error_text = None
         else:
             exe_time = round(random.uniform(0.01, problem.time_limit * 0.85), 3)
             mem = round(random.uniform(2048, problem.memory_limit * 0.7), 1)
             sub_lang = lang if result == "AC" else (cpp_lang or lang)
+            error_text = None
 
         pts = float(problem.points) if result == "AC" else 0.0
+        case_pts = pts
+        case_total = float(problem.points)
+
+        # Submission date: random point in the past 90 days
+        sub_date = now - timedelta(
+            days=random.randint(0, 90),
+            hours=random.randint(0, 23),
+            minutes=random.randint(0, 59),
+            seconds=random.randint(0, 59),
+        )
+        # Judging completes a few seconds to minutes after submission
+        judged_date = sub_date + timedelta(seconds=random.uniform(2, 120))
 
         sub = Submission.objects.create(
             user=profile,
@@ -711,28 +848,30 @@ class Command(BaseCommand):
             time=exe_time,
             memory=mem,
             points=pts,
-            case_points=pts,
-            case_total=float(problem.points),
+            case_points=case_pts,
+            case_total=case_total,
+            error=error_text,
+            current_testcase=0,
+            batch=False,
+            judged_on=dev_judge,
+            judged_date=judged_date,
+            was_rejudged=False,
+            is_pretested=False,
+            contest_object=None,
         )
         # auto_now_add=True prevents setting date in create(), use update()
-        Submission.objects.filter(pk=sub.pk).update(
-            date=now
-            - timedelta(
-                days=random.randint(0, 90),
-                hours=random.randint(0, 23),
-                minutes=random.randint(0, 59),
-            )
-        )
+        Submission.objects.filter(pk=sub.pk).update(date=sub_date)
+
         SubmissionSource.objects.get_or_create(
             submission=sub,
             defaults=dict(source=_src_for(result, lang_key)),
         )
         return 1
 
-    # ── Recompute points ──────────────────────────────────────────────────────
+    # ── Recompute stats ───────────────────────────────────────────────────────
 
-    def _update_user_points(self, profiles):
-        self.stdout.write("\n── Recomputing user points")
+    def _update_user_stats(self, profiles):
+        self.stdout.write("\n── Recomputing user stats")
         from judge.models import Submission
 
         for profile in profiles:
@@ -741,8 +880,32 @@ class Command(BaseCommand):
                 .values("problem_id")
                 .annotate(best=Max("points"))
             )
-            total = sum(row["best"] or 0 for row in best)
-            profile.points = total
-            profile.save(update_fields=["points"])
+            total_pts = sum(row["best"] or 0 for row in best)
+            solved_count = best.count()
+
+            profile.points = total_pts
+            profile.problem_count = solved_count
+            profile.save(update_fields=["points", "problem_count"])
 
         self.stdout.write(f"  updated {len(profiles)} profiles")
+
+    def _update_problem_stats(self, problems):
+        self.stdout.write("\n── Recomputing problem stats")
+        from judge.models import Submission
+
+        for problem in problems:
+            subs = Submission.objects.filter(problem=problem, status="D")
+            total = subs.count()
+            ac = subs.filter(result="AC").count()
+            solvers = (
+                Submission.objects.filter(problem=problem, result="AC")
+                .values("user_id")
+                .distinct()
+                .count()
+            )
+
+            problem.user_count = solvers
+            problem.ac_rate = round((ac / total * 100) if total > 0 else 0.0, 1)
+            problem.save(update_fields=["user_count", "ac_rate"])
+
+        self.stdout.write(f"  updated {len(problems)} problems")

--- a/templates/submission/row.html
+++ b/templates/submission/row.html
@@ -76,7 +76,7 @@
   {% else %}
     {% if "TLE" != submission.result %}
       <div title="{{ submission.time or 0 }}s" class="time">
-        {{ (submission.time * 1000 or 0)|floatformat(0) }} ms
+        {{ ((submission.time or 0) * 1000)|floatformat(0) }} ms
       </div>
     {% else %}
       <div class="time">---</div>


### PR DESCRIPTION
**Purpose: for convenient dev and testing on non-Linux environment**



All Docker config consolidated under .docker/dev-local/:
  - docker-compose.yml      service definitions (MariaDB, Memcached, Redis, web)
  - Dockerfile              Ubuntu 22.04 image matching production
  - docker-entrypoint.sh   startup: SCSS compile, migrate, fixtures, runserver
  - .dockerignore
  - local_settings_docker.py  Django settings for container (mysqlclient, no pymysql)
  - mariadb-init/01-timezone.sh  loads tz data on first DB start
  - README.md               full dev guide: platform support, rebuild reference, one-liners
  - HANDOFF.md + .gitattributes  copied for source code provenance

Also adds judge/management/commands/seed_dev_data.py — PCT-based management command that seeds 1 admin + 60 users + 210 problems + 27 contests + ~8k submissions for local development.