### PR TITLE
Fix paginated rank for ties spanning page boundaries

### DIFF
--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -123,6 +123,7 @@ __all__ = [
     "get_ranking_queryset",
     "get_contest_problems",
     "build_ranking_profiles",
+    "compute_ranks",
     "ContestClarificationView",
     "OfficialContestList",
     "RecommendedContestList",
@@ -1653,11 +1654,11 @@ class ContestRanking(ContestRankingBase):
         )
         profiles = build_ranking_profiles(contest, problems, qs, self.show_final)
 
-        users = ranker(
-            profiles,
-            key=attrgetter("points", "cumtime", "tiebreaker"),
-            rank=start,
+        rank_map = compute_ranks(
+            ((pid, s, c, tb) for pid, _uid, s, c, tb in filtered_rows),
+            target_ids=set(page_ids),
         )
+        users = ((rank_map[p.participation.id], p) for p in profiles)
 
         # Build page_obj for template pagination
         self.page_obj = DiggPaginator(

--- a/judge/views/organization.py
+++ b/judge/views/organization.py
@@ -63,7 +63,6 @@ from judge.models import (
 from judge.models.course import RoleInCourse
 from judge.models.notification import Notification, NotificationCategory
 from judge.models.block import get_all_blocked_pairs
-from judge.utils.ranker import ranker
 from judge.utils.views import (
     TitleMixin,
     generic_message,
@@ -72,7 +71,7 @@ from judge.utils.views import (
 )
 from judge.utils.problems import user_attempted_ids, user_completed_ids
 from judge.views.problem import ProblemList
-from judge.views.contests import ContestList
+from judge.views.contests import ContestList, compute_ranks
 from judge.views.course import CourseList
 from judge.views.submission import SubmissionsListBase
 from judge.utils.feed import build_home_feed
@@ -735,9 +734,16 @@ class OrganizationUsers(
             "organization_user_kick",
             args=[self.organization.id, self.organization.slug],
         )
-        context["users"] = ranker(
-            context["users"], rank=self.paginate_by * (context["page_obj"].number - 1)
-        )
+        page_ids = {u.id for u in context["users"]}
+        if page_ids:
+            full_rows = self.object_list.values_list("id", "points")
+            rank_map = compute_ranks(
+                ((pid, points, 0, 0) for pid, points in full_rows),
+                target_ids=page_ids,
+            )
+            context["users"] = [(rank_map.get(u.id, 1), u) for u in context["users"]]
+        else:
+            context["users"] = []
 
         context["page_type"] = "users"
         context.update(self.get_sort_context())

--- a/judge/views/user.py
+++ b/judge/views/user.py
@@ -47,7 +47,7 @@ from judge.performance_points import get_pp_breakdown
 from judge.ratings import rating_class, rating_progress
 from judge.tasks import import_users
 from judge.utils.problems import contest_completed_ids, user_completed_ids
-from judge.utils.ranker import ranker
+from judge.views.contests import compute_ranks
 from judge.utils.unicode import utf8text
 from judge.models.profile import get_rating_rank, get_points_rank, get_contribution_rank
 from judge.utils.users import (
@@ -472,9 +472,16 @@ class UserList(QueryStringSortMixin, InfinitePaginationMixin, TitleMixin, ListVi
         context = super(UserList, self).get_context_data(**kwargs)
         Profile.get_cached_instances(*[u.id for u in context["users"]])
         Profile.prefetch_cache_about(*[u.id for u in context["users"]])
-        context["users"] = ranker(
-            context["users"], rank=self.paginate_by * (context["page_obj"].number - 1)
-        )
+        page_ids = {u.id for u in context["users"]}
+        if page_ids:
+            full_rows = self.object_list.values_list("id", "points")
+            rank_map = compute_ranks(
+                ((pid, points, 0, 0) for pid, points in full_rows),
+                target_ids=page_ids,
+            )
+            context["users"] = [(rank_map.get(u.id, 1), u) for u in context["users"]]
+        else:
+            context["users"] = []
         context["first_page_href"] = "."
         context["page_type"] = "friends" if self.filter_friend else "list"
         context.update(self.get_sort_context())


### PR DESCRIPTION
Replace ranker(slice, rank=offset) with compute_ranks lookup over the full sorted list in contest scoreboard, user leaderboard, and org member list. The old pattern couldn't detect ties spanning page boundaries, so users tied at the same score got different ranks across pages (e.g. all rank 1 on page 1, all rank 101 on page 2).