### PR TITLE
Polish review check labels, translations, and dashboard noise

### DIFF
--- a/judge/review/checks/artifacts_present.py
+++ b/judge/review/checks/artifacts_present.py
@@ -1,16 +1,20 @@
-"""artifacts_present: statement, >=1 test, checker key, main AC source uploaded.
+"""artifacts_present: statement, >=1 test source, checker key, main AC source uploaded.
+
+`test_data` is considered present if ANY of:
+  - `ProblemData.zipfile` (uploaded zip of pre-built test cases), OR
+  - `ProblemData.generator` (uploaded generator binary), OR
+  - `ProblemData.generator_script` (in-DB generator script text).
+LQDOJ supports all three at grading time, so the check accepts any.
 
 `main_ac_source` is considered present if EITHER:
   - The author uploaded a `ProblemSolutionCode` blob via the Solution Codes
     sidebar tab, OR
   - The author tagged at least one Submission as a reference via the
     "Reference solutions for review" panel (`ProblemReviewSubmissionTag`).
-Both surfaces capture "we have a reference AC for this problem" from
-slightly different angles; either is sufficient evidence.
 """
 
 from django.conf import settings
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext as _, gettext_lazy
 
 from judge.models.problem_data import ProblemData, ProblemSolutionCode
 from judge.models.problem_review import (
@@ -20,9 +24,23 @@ from judge.models.problem_review import (
 from judge.review.base import ProblemReviewCheck, CheckResultData
 
 
+def _artifact_label(token):
+    """Map internal token → user-facing localized label.
+
+    Built per-call (not module load) so gettext sees the active language.
+    """
+    labels = {
+        "statement": _("statement"),
+        "test_data": _("test data"),
+        "checker": _("checker"),
+        "main_ac_source": _("main AC source"),
+    }
+    return labels.get(token, token)
+
+
 class ArtifactsPresentCheck(ProblemReviewCheck):
     id = "artifacts_present"
-    display_name = "Artifacts present"
+    display_name = gettext_lazy("Artifacts")
 
     def run(self, problem, run):
         min_chars = getattr(settings, "AUTO_REVIEW_STATEMENT_MIN_CHARS", 100)
@@ -41,7 +59,14 @@ class ArtifactsPresentCheck(ProblemReviewCheck):
         except ProblemData.DoesNotExist:
             pd = None
 
-        if pd and pd.zipfile and pd.zipfile.name:
+        # Test data: accept zip OR generator binary OR generator script.
+        # Problems vary in which path they use; the judge supports all three.
+        has_test_data = pd is not None and (
+            (pd.zipfile and pd.zipfile.name)
+            or (pd.generator and pd.generator.name)
+            or bool((pd.generator_script or "").strip())
+        )
+        if has_test_data:
             present.append("test_data")
         else:
             missing.append("test_data")
@@ -61,9 +86,12 @@ class ArtifactsPresentCheck(ProblemReviewCheck):
             missing.append("main_ac_source")
 
         if missing:
+            # Localize each token so the FAIL reason reads naturally in vi.
+            missing_labels = [str(_artifact_label(t)) for t in missing]
             return CheckResultData(
                 status=ProblemReviewCheckResult.FAIL,
-                reason=_("Missing: %(missing)s") % {"missing": ", ".join(missing)},
+                reason=_("Missing: %(missing)s")
+                % {"missing": ", ".join(missing_labels)},
                 details={"present": present, "missing": missing},
             )
         return CheckResultData(

--- a/judge/review/checks/checker_correctness.py
+++ b/judge/review/checks/checker_correctness.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext as _, gettext_lazy
 
 from judge.models.problem_data import ProblemData
 from judge.models.problem_review import ProblemReviewCheckResult
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 class CheckerCorrectnessCheck(ProblemReviewCheck):
     id = "checker_correctness"
-    display_name = "Checker correctness"
+    display_name = gettext_lazy("Checker")
 
     def run(self, problem, run):
         try:

--- a/judge/review/checks/duplicate_detection.py
+++ b/judge/review/checks/duplicate_detection.py
@@ -3,7 +3,7 @@
 import logging
 
 from django.conf import settings
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext as _, gettext_lazy
 
 from judge.ml.semantic_search import (
     SemanticSearchUnavailable,
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 class DuplicateDetectionCheck(ProblemReviewCheck):
     id = "duplicate_detection"
-    display_name = "Duplicate detection"
+    display_name = gettext_lazy("Duplicates")
 
     def run(self, problem, run):
         if not getattr(settings, "USE_ML", False):

--- a/judge/review/checks/solutions_rubric.py
+++ b/judge/review/checks/solutions_rubric.py
@@ -8,7 +8,7 @@ whole set against the problem statement, classifies each submission's role
 import json
 import logging
 
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext as _, gettext_lazy
 
 from judge.models.problem_review import (
     ProblemReviewCheckResult,
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 class SolutionsRubricCheck(ProblemReviewCheck):
     id = "solutions_rubric"
-    display_name = "Solutions rubric"
+    display_name = gettext_lazy("Solutions")
 
     def run(self, problem, run):
         tags = list(

--- a/judge/review/checks/time_limit_headroom.py
+++ b/judge/review/checks/time_limit_headroom.py
@@ -1,7 +1,7 @@
 """time_limit_headroom: main AC submissions must use < TL_HEADROOM_RATIO of TL."""
 
 from django.conf import settings
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext as _, gettext_lazy
 
 from judge.models.problem_review import (
     ProblemReviewCheckResult,
@@ -12,7 +12,7 @@ from judge.review.base import ProblemReviewCheck, CheckResultData
 
 class TimeLimitHeadroomCheck(ProblemReviewCheck):
     id = "time_limit_headroom"
-    display_name = "Time-limit headroom"
+    display_name = gettext_lazy("Time limit")
 
     def run(self, problem, run):
         ratio_threshold = getattr(settings, "AUTO_REVIEW_TL_HEADROOM_RATIO", 0.8)

--- a/judge/review/checks/validator_runs_clean.py
+++ b/judge/review/checks/validator_runs_clean.py
@@ -11,7 +11,7 @@ path uses. Deferred from v1 — see `VALIDATOR_GENERATION_SYSTEM` in
 `judge/review/prompts.py` for the prompt skeleton.
 """
 
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext as _, gettext_lazy
 
 from judge.models.problem_data import ProblemData, ProblemValidation
 from judge.models.problem_review import ProblemReviewCheckResult
@@ -20,7 +20,7 @@ from judge.review.base import CheckResultData, ProblemReviewCheck
 
 class ValidatorRunsCleanCheck(ProblemReviewCheck):
     id = "validator_runs_clean"
-    display_name = "Validator runs clean"
+    display_name = gettext_lazy("Validator")
 
     def run(self, problem, run):
         try:

--- a/locale/vi/LC_MESSAGES/django.po
+++ b/locale/vi/LC_MESSAGES/django.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lqdoj2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-01 13:43+0700\n"
+"POT-Creation-Date: 2026-06-02 16:53+0700\n"
 "PO-Revision-Date: 2021-07-20 03:44\n"
 "Last-Translator: Icyene\n"
 "Language-Team: Vietnamese\n"
@@ -33,7 +33,7 @@ msgid "user"
 msgstr "người dùng"
 
 #: chat_box/models.py:164 judge/models/comment.py:133
-#: judge/models/notification.py:318
+#: judge/models/notification.py:320
 msgid "posted time"
 msgstr "thời gian đăng"
 
@@ -2060,80 +2060,79 @@ msgstr "Yêu cầu công khai được chấp nhận"
 msgid "Public request rejected"
 msgstr "Yêu cầu công khai bị từ chối"
 
-#: judge/models/notification.py:34
+#: judge/models/notification.py:35
 msgid "Auto-review completed"
 msgstr "Tự động xem xét hoàn tất"
 
-#: judge/models/notification.py:35
-#| msgid "Runtime Error"
+#: judge/models/notification.py:37
 msgid "Auto-review error"
 msgstr "Lỗi tự động xem xét"
 
-#: judge/models/notification.py:312
+#: judge/models/notification.py:314
 msgid "owner"
 msgstr "chủ sở hữu"
 
-#: judge/models/notification.py:321
+#: judge/models/notification.py:323
 msgid "category"
 msgstr "danh mục"
 
-#: judge/models/notification.py:328
+#: judge/models/notification.py:330
 msgid "html link to comments, used for non-comments"
 msgstr "liên kết html đến bình luận, dùng cho không phải bình luận"
 
-#: judge/models/notification.py:335
+#: judge/models/notification.py:337
 msgid "who triggered, used for non-comment"
 msgstr "ai kích hoạt, dùng cho không phải bình luận"
 
-#: judge/models/notification.py:341
+#: judge/models/notification.py:343
 msgid "is read"
 msgstr "đã đọc"
 
-#: judge/models/notification.py:347
+#: judge/models/notification.py:349
 msgid "read at"
 msgstr "đọc lúc"
 
-#: judge/models/notification.py:352
+#: judge/models/notification.py:354
 msgid "extra data"
 msgstr "dữ liệu bổ sung"
 
-#: judge/models/notification.py:353
+#: judge/models/notification.py:355
 msgid "Additional data for complex notifications"
 msgstr "Dữ liệu bổ sung cho thông báo phức tạp"
 
-#: judge/models/notification.py:365
+#: judge/models/notification.py:367
 msgid "notification"
 msgstr "thông báo"
 
-#: judge/models/notification.py:366
+#: judge/models/notification.py:368
 msgid "notifications"
 msgstr "thông báo"
 
-#: judge/models/notification.py:388
+#: judge/models/notification.py:390
 msgid "The problem is public to: "
 msgstr "Bài tập được công khai trong: "
 
-#: judge/models/notification.py:390
+#: judge/models/notification.py:392
 msgid "The problem is private to: "
 msgstr "Bài tập riêng tư trong: "
 
-#: judge/models/notification.py:393
+#: judge/models/notification.py:395
 msgid "The problem is public to everyone."
 msgstr "Bài tập được công khai với mọi người."
 
-#: judge/models/notification.py:395
+#: judge/models/notification.py:397
 msgid "The problem is private."
 msgstr "Bài tập được đánh dấu riêng tư."
 
-#: judge/models/notification.py:420
+#: judge/models/notification.py:422
 msgid "last read time"
 msgstr "thời gian đọc cuối"
 
-#: judge/models/notification.py:424
+#: judge/models/notification.py:426
 msgid "notification profile"
 msgstr "hồ sơ thông báo"
 
-#: judge/models/notification.py:425
+#: judge/models/notification.py:427
 msgid "notification profiles"
 msgstr "hồ sơ thông báo"
 
@@ -2586,6 +2585,7 @@ msgid "init.yml generation feedback"
 msgstr "phản hồi của quá trình tạo file init.yml"
 
 #: judge/models/problem_data.py:103 judge/models/problem_data.py:365
+#: judge/review/checks/artifacts_present.py:35
 msgid "checker"
 msgstr "trình chấm"
 
@@ -2901,7 +2901,6 @@ msgid "Marked not duplicated"
 msgstr "Đánh dấu riêng tư"
 
 #: judge/models/problem_review.py:28
-#| msgid "reviewed by"
 msgid "triggered by"
 msgstr "kích hoạt bởi"
 
@@ -2919,7 +2918,6 @@ msgid "sha256 of problem state used by dirty-check"
 msgstr ""
 
 #: judge/models/problem_review.py:42 judge/models/problem_review.py:115
-#| msgid "Started"
 msgid "started at"
 msgstr "bắt đầu lúc"
 
@@ -2932,28 +2930,23 @@ msgid "summary report"
 msgstr ""
 
 #: judge/models/problem_review.py:53
-#| msgid "requested by"
 msgid "superseded by"
 msgstr "được thay thế bởi"
 
 #: judge/models/problem_review.py:57
-#| msgid "problem group"
 msgid "problem review run"
 msgstr "lần chạy xem xét đề"
 
 #: judge/models/problem_review.py:58
-#| msgid "problem groups"
 msgid "problem review runs"
 msgstr "các lần chạy xem xét đề"
 
 #: judge/models/problem_review.py:93 templates/internal/problem_queue.html:756
 #: templates/problem/edit.html:700
-#| msgid "Password"
 msgid "Pass"
 msgstr "Đạt"
 
 #: judge/models/problem_review.py:94 templates/internal/problem_queue.html:757
-#| msgid "Failed to run."
 msgid "Fail"
 msgstr "Không đạt"
 
@@ -2963,12 +2956,10 @@ msgid "Skipped"
 msgstr "Bỏ qua"
 
 #: judge/models/problem_review.py:103
-#| msgid "Preview"
 msgid "review run"
 msgstr "lần chạy xem xét"
 
 #: judge/models/problem_review.py:105
-#| msgid "checker"
 msgid "check id"
 msgstr "id kiểm tra"
 
@@ -2978,7 +2969,6 @@ msgid "reason"
 msgstr "lý do"
 
 #: judge/models/problem_review.py:113
-#| msgid "Details"
 msgid "details"
 msgstr "chi tiết"
 
@@ -2995,7 +2985,6 @@ msgid "Main AC"
 msgstr ""
 
 #: judge/models/problem_review.py:137
-#| msgid "Subtask"
 msgid "Subtask-targeted"
 msgstr "Nhắm subtask"
 
@@ -3004,7 +2993,6 @@ msgid "Brute force / suboptimal"
 msgstr ""
 
 #: judge/models/problem_review.py:152
-#| msgid "Merged by"
 msgid "tagged by"
 msgstr "gắn bởi"
 
@@ -3017,7 +3005,6 @@ msgid "Optional — the LLM will classify if not set."
 msgstr ""
 
 #: judge/models/problem_review.py:165
-#| msgid "hidden subtasks"
 msgid "target subtask"
 msgstr "subtask đích"
 
@@ -3030,7 +3017,6 @@ msgid "claimed complexity"
 msgstr ""
 
 #: judge/models/problem_review.py:173
-#| msgid "authors"
 msgid "author note"
 msgstr "ghi chú tác giả"
 
@@ -3044,12 +3030,10 @@ msgid "updated at"
 msgstr "cập nhật lúc"
 
 #: judge/models/problem_review.py:178
-#| msgid "All friend submissions"
 msgid "problem review submission tag"
 msgstr "tag bài nộp xem xét"
 
 #: judge/models/problem_review.py:179
-#| msgid "All friend submissions"
 msgid "problem review submission tags"
 msgstr "các tag bài nộp xem xét"
 
@@ -4229,24 +4213,45 @@ msgstr "Trang [page]/[topage]"
 msgid "Page %(page)s of %(total)s"
 msgstr "Trang %(page)s/%(total)s"
 
-#: judge/review/checks/artifacts_present.py:66
-#, fuzzy, python-format
-#| msgid "Modifying submissions"
-msgid "Missing: %(missing)s"
-msgstr "Chỉnh sửa bài nộp"
+#: judge/review/checks/artifacts_present.py:33
+msgid "statement"
+msgstr "đề bài"
 
-#: judge/review/checks/artifacts_present.py:71
+#: judge/review/checks/artifacts_present.py:34
+msgid "test data"
+msgstr "dữ liệu test"
+
+#: judge/review/checks/artifacts_present.py:36
+msgid "main AC source"
+msgstr "mã nguồn AC chính"
+
+#: judge/review/checks/artifacts_present.py:43
+#| msgid "Artifacts present"
+msgid "Artifacts"
+msgstr "Artifact"
+
+#: judge/review/checks/artifacts_present.py:93
+#, python-format
+msgid "Missing: %(missing)s"
+msgstr "Còn thiếu: %(missing)s"
+
+#: judge/review/checks/artifacts_present.py:99
 msgid "All artifacts uploaded."
-msgstr ""
+msgstr "Tất cả artifact đã được tải lên."
+
+#: judge/review/checks/checker_correctness.py:18
+#: templates/problem/import.html:39
+msgid "Checker"
+msgstr "Trình chấm"
 
 #: judge/review/checks/checker_correctness.py:26
 msgid "No ProblemData configured."
-msgstr ""
+msgstr "Chưa cấu hình ProblemData."
 
 #: judge/review/checks/checker_correctness.py:44
 #, python-format
 msgid "Multi-output detection failed: %(error)s"
-msgstr ""
+msgstr "Phát hiện đa-đáp-án thất bại: %(error)s"
 
 #: judge/review/checks/checker_correctness.py:51
 msgid ""
@@ -4259,47 +4264,48 @@ msgid "Floating-point checker matches statement's tolerance requirement."
 msgstr ""
 
 #: judge/review/checks/checker_correctness.py:71
-#, fuzzy, python-format
-#| msgid "No judge is available for this problem."
+#, python-format
 msgid "Checker '%(key)s' is appropriate for this problem."
-msgstr "Không có máy chấm có thể chấm bài này."
+msgstr "Checker '%(key)s' phù hợp với đề bài."
 
 #: judge/review/checks/checker_correctness.py:99
 msgid "Checker is set to custom but no checker source is uploaded."
 msgstr ""
+"Checker được đặt là custom nhưng chưa có mã nguồn checker được upload."
 
 #: judge/review/checks/checker_correctness.py:111
 #, python-format
 msgid "Custom checker validation failed: %(error)s"
-msgstr ""
+msgstr "Kiểm tra checker custom thất bại: %(error)s"
 
 #: judge/review/checks/checker_correctness.py:118
-#, fuzzy
-#| msgid "Custom checker (PY)"
 msgid "Custom checker appears correct."
-msgstr "Trình chấm tự viết (Python)"
+msgstr "Checker custom có vẻ chính xác."
 
 #: judge/review/checks/checker_correctness.py:123
-#, fuzzy, python-format
-#| msgid "Custom checker (PY)"
+#, python-format
 msgid "Custom checker issues: %(reason)s"
-msgstr "Trình chấm tự viết (Python)"
+msgstr "Vấn đề với checker custom: %(reason)s"
+
+#: judge/review/checks/duplicate_detection.py:20
+#| msgid "Duplicate Problems"
+msgid "Duplicates"
+msgstr "Đề trùng lặp"
 
 #: judge/review/checks/duplicate_detection.py:27
 msgid "USE_ML is disabled — semantic duplicate detection unavailable."
 msgstr ""
+"USE_ML đang tắt — không thể phát hiện đề trùng lặp bằng tìm kiếm ngữ nghĩa."
 
 #: judge/review/checks/duplicate_detection.py:37
-#, fuzzy, python-format
-#| msgid "Semantic search over public problems."
+#, python-format
 msgid "Semantic search unavailable: %(error)s"
-msgstr "Tìm kiếm ngữ nghĩa trên các bài công khai."
+msgstr "Tìm kiếm ngữ nghĩa không khả dụng: %(error)s"
 
 #: judge/review/checks/duplicate_detection.py:43
-#, fuzzy, python-format
-#| msgid "Semantic search over public problems."
+#, python-format
 msgid "Semantic search error: %(error)s"
-msgstr "Tìm kiếm ngữ nghĩa trên các bài công khai."
+msgstr "Lỗi tìm kiếm ngữ nghĩa: %(error)s"
 
 #: judge/review/checks/duplicate_detection.py:55
 #, python-format
@@ -4310,7 +4316,12 @@ msgstr ""
 #: judge/review/checks/duplicate_detection.py:65
 #, python-format
 msgid "No similar public problem above threshold %(threshold).2f."
-msgstr ""
+msgstr "Không có đề công khai nào tương tự vượt ngưỡng %(threshold).2f."
+
+#: judge/review/checks/solutions_rubric.py:26
+#: templates/problem/edit_base.html:18 templates/problem/import.html:30
+msgid "Solutions"
+msgstr "Bài giải"
 
 #: judge/review/checks/solutions_rubric.py:42
 msgid ""
@@ -4338,11 +4349,14 @@ msgstr "Rubric phát hiện vấn đề."
 msgid " (+%(more)d more)"
 msgstr ""
 
+#: judge/review/checks/time_limit_headroom.py:15
+#| msgid "Time limit:"
+msgid "Time limit"
+msgstr "Giới hạn thời gian"
+
 #: judge/review/checks/time_limit_headroom.py:23
-#, fuzzy
-#| msgid "time limit"
 msgid "No time limit set."
-msgstr "giới hạn thời gian"
+msgstr "Chưa đặt giới hạn thời gian."
 
 #: judge/review/checks/time_limit_headroom.py:43
 msgid ""
@@ -4362,25 +4376,28 @@ msgstr ""
 #: judge/review/checks/time_limit_headroom.py:86
 #, python-format
 msgid "All main AC submissions use < %(threshold)d%% of the time limit."
-msgstr ""
+msgstr "Tất cả các bài Main AC dùng < %(threshold)d%% giới hạn thời gian."
+
+#: judge/review/checks/validator_runs_clean.py:23
+#| msgid "Run Validator"
+msgid "Validator"
+msgstr "Validator"
 
 #: judge/review/checks/validator_runs_clean.py:31
-#, fuzzy
-#| msgid "problem data set"
 msgid "No problem data configured."
-msgstr "tập hợp dữ liệu bài"
+msgstr "Chưa cấu hình dữ liệu bài."
 
 #: judge/review/checks/validator_runs_clean.py:43
 msgid ""
 "No validator configured — add one in problem data to enable this check. A "
 "validator is recommended for high-quality CP problems."
 msgstr ""
+"Chưa cấu hình validator — hãy thêm trong phần dữ liệu đề để bật check này. "
+"Validator được khuyến khích cho các đề lập trình thi đấu chất lượng cao."
 
 #: judge/review/checks/validator_runs_clean.py:50
-#, fuzzy
-#| msgid "Validation failed."
 msgid "Validator is configured."
-msgstr "Kiểm tra thất bại."
+msgstr "Validator đã được cấu hình."
 
 #: judge/social_auth.py:69 judge/views/register.py:34
 msgid "A username must contain letters, numbers, or underscores"
@@ -6061,113 +6078,113 @@ msgstr "Chỉnh sửa {0}"
 msgid "Editing problem for %s"
 msgstr "Chỉnh sửa bài tập cho %s"
 
-#: judge/views/problem.py:1486 judge/views/problem.py:1490
+#: judge/views/problem.py:1485 judge/views/problem.py:1489
 #, python-format
 msgid "Edit history for %s"
 msgstr "Lịch sử chỉnh sửa %s"
 
-#: judge/views/problem.py:1748
+#: judge/views/problem.py:1747
 msgid "Add Problem"
 msgstr "Thêm bài tập"
 
-#: judge/views/problem.py:1780
+#: judge/views/problem.py:1779
 #, python-format
 msgid "Problem '%(name)s' has been created successfully!"
 msgstr "Bài tập '%(name)s' đã được tạo thành công!"
 
-#: judge/views/problem.py:1806
+#: judge/views/problem.py:1805
 #, python-brace-format
 msgid "Edit Language Limits - {0}"
 msgstr "Chỉnh sửa giới hạn ngôn ngữ - {0}"
 
-#: judge/views/problem.py:1810
+#: judge/views/problem.py:1809
 #, python-format
 msgid "Editing language limits for %s"
 msgstr "Chỉnh sửa giới hạn ngôn ngữ cho %s"
 
-#: judge/views/problem.py:1912
+#: judge/views/problem.py:1911
 #, python-brace-format
 msgid "Edit Language Templates - {0}"
 msgstr "Chỉnh sửa code mẫu - {0}"
 
-#: judge/views/problem.py:1916
+#: judge/views/problem.py:1915
 #, python-format
 msgid "Editing language templates for %s"
 msgstr "Chỉnh sửa code mẫu cho %s"
 
-#: judge/views/problem.py:1962
+#: judge/views/problem.py:1961
 msgid "Language template deleted successfully."
 msgstr "Đoạn code mẫu được xóa thành công."
 
-#: judge/views/problem.py:1964 judge/views/problem.py:1983
+#: judge/views/problem.py:1963 judge/views/problem.py:1982
 msgid "Language template not found."
 msgstr "Code mẫu không tìm thấy"
 
-#: judge/views/problem.py:1978
+#: judge/views/problem.py:1977
 msgid "Language template updated successfully."
 msgstr "Đoạn code mẫu được cập nhật thành công"
 
-#: judge/views/problem.py:1995
+#: judge/views/problem.py:1994
 msgid "Language template added successfully."
 msgstr "Code mẫu được thêm thành công"
 
-#: judge/views/problem.py:2029
+#: judge/views/problem.py:2028
 #, python-brace-format
 msgid "Edit Solutions - {0}"
 msgstr "Chỉnh sửa lời giải - {0}"
 
-#: judge/views/problem.py:2033
+#: judge/views/problem.py:2032
 #, python-format
 msgid "Editing solutions for %s"
 msgstr "Chỉnh sửa lời giải cho %s"
 
-#: judge/views/problem.py:2089
+#: judge/views/problem.py:2088
 msgid "Solution deleted successfully."
 msgstr "Lời giải đã xóa thành công"
 
-#: judge/views/problem.py:2091
+#: judge/views/problem.py:2090
 msgid "Solution not found."
 msgstr "Lời giải không tìm thấy"
 
-#: judge/views/problem.py:2100
+#: judge/views/problem.py:2099
 msgid "Solution updated successfully."
 msgstr "Lời giải cập nhật thành công"
 
-#: judge/views/problem.py:2105
+#: judge/views/problem.py:2104
 msgid "A solution already exists for this problem."
 msgstr "Lời giải đã tồn tại cho bài tập này."
 
-#: judge/views/problem.py:2113
+#: judge/views/problem.py:2112
 msgid "Solution added successfully."
 msgstr "Lời giải được thêm thành công"
 
-#: judge/views/problem.py:2181
+#: judge/views/problem.py:2180
 #, python-brace-format
 msgid "Edit Translations - {0}"
 msgstr "Chỉnh sửa bản dịch - {0}"
 
-#: judge/views/problem.py:2185
+#: judge/views/problem.py:2184
 #, python-format
 msgid "Editing translations for %s"
 msgstr "Chỉnh sửa bản dịch cho %s"
 
-#: judge/views/problem.py:2237
+#: judge/views/problem.py:2236
 msgid "Translation deleted successfully."
 msgstr "Bản dịch cập nhật thành công"
 
-#: judge/views/problem.py:2239 judge/views/problem.py:2294
+#: judge/views/problem.py:2238 judge/views/problem.py:2293
 msgid "Translation not found."
 msgstr "Bản dịch không tìm thấy"
 
-#: judge/views/problem.py:2258
+#: judge/views/problem.py:2257
 msgid "Translation updated successfully."
 msgstr "Bản dịch cập nhật thành công"
 
-#: judge/views/problem.py:2306
+#: judge/views/problem.py:2305
 msgid "A translation for this language already exists."
 msgstr "Bản dịch với ngôn ngữ này đã tồn tại"
 
-#: judge/views/problem.py:2315
+#: judge/views/problem.py:2314
 msgid "Translation added successfully."
 msgstr "Bản dịch được thêm thành công"
 
@@ -9326,7 +9343,6 @@ msgid "Reviewed by"
 msgstr "Duyệt bởi"
 
 #: templates/internal/problem_queue.html:751 templates/problem/edit.html:698
-#| msgid "Preview"
 msgid "Auto-review"
 msgstr "Tự động xem xét"
 
@@ -10442,22 +10458,18 @@ msgid "Insert"
 msgstr "Chèn"
 
 #: templates/problem/edit.html:477
-#| msgid "Best solutions for %s"
 msgid "Reference solutions for review"
 msgstr "Các bài nộp tham chiếu cho xem xét"
 
 #: templates/problem/edit.html:481
-#| msgid "Generate Solution"
 msgid "Reference solutions"
 msgstr "Bài nộp tham chiếu"
 
 #: templates/problem/edit.html:483
-#| msgid "Attached files"
 msgid "attached"
 msgstr "đã gắn"
 
 #: templates/problem/edit.html:485
-#| msgid "problem attachment"
 msgid "none attached"
 msgstr "chưa gắn bài nào"
 
@@ -10473,17 +10485,14 @@ msgstr ""
 "kiểm tra tính đúng đắn, độ phức tạp và độ bao phủ subtask."
 
 #: templates/problem/edit.html:497
-#| msgid "No questions added yet."
 msgid "No reference solutions attached yet."
 msgstr "Chưa có bài nộp tham chiếu nào."
 
 #: templates/problem/edit.html:528
-#| msgid "Submission"
 msgid "Submission ID"
 msgstr "ID bài nộp"
 
 #: templates/problem/edit.html:530
-#| msgid "Attachments"
 msgid "Attach"
 msgstr "Gắn"
 
@@ -10496,7 +10505,6 @@ msgid "Awaiting admin approval."
 msgstr "Đang chờ admin duyệt."
 
 #: templates/problem/edit.html:677
-#| msgid "Review"
 msgid "Re-run review"
 msgstr "Chạy lại xem xét"
 
@@ -10505,12 +10513,10 @@ msgid "Re-request Public"
 msgstr "Yêu cầu lại"
 
 #: templates/problem/edit.html:702
-#| msgid "No quizzes found"
 msgid "Issues found"
 msgstr "Có vấn đề"
 
 #: templates/problem/edit.html:704
-#| msgid "Running"
 msgid "Running…"
 msgstr "Đang chạy…"
 
@@ -10521,12 +10527,10 @@ msgid "Rejection feedback:"
 msgstr "phản hồi từ máy chấm"
 
 #: templates/problem/edit.html:747
-#| msgid "Filter submissions"
 msgid "Please enter a submission ID."
 msgstr "Vui lòng nhập ID bài nộp."
 
 #: templates/problem/edit.html:753
-#| msgid "Attached files"
 msgid "Attach failed."
 msgstr "Gắn bài nộp thất bại."
 
@@ -10550,10 +10554,6 @@ msgstr "Ngôn ngữ"
 #: templates/problem/edit_base.html:17
 msgid "Templates"
 msgstr "Code mẫu"
-
-#: templates/problem/edit_base.html:18 templates/problem/import.html:30
-msgid "Solutions"
-msgstr "Lời giải"
 
 #: templates/problem/edit_base.html:19
 msgid "Translate"
@@ -10652,10 +10652,6 @@ msgstr "ảnh"
 #: templates/problem/import.html:35
 msgid "Images included"
 msgstr "Ảnh đính kèm"
-
-#: templates/problem/import.html:39
-msgid "Checker"
-msgstr "Trình chấm"
 
 #: templates/problem/import.html:40
 msgid "Generator"
@@ -11018,7 +11014,6 @@ msgid "Recommended problems"
 msgstr "Bài tập gợi ý"
 
 #: templates/problem/review.html:23
-#| msgid "No edit history available for this problem."
 msgid "No review run yet for this problem."
 msgstr "Chưa có lần chạy xem xét nào cho bài này."
 
@@ -11028,22 +11023,18 @@ msgid "Run"
 msgstr "Lần chạy"
 
 #: templates/problem/review.html:54
-#| msgid "reviewed by"
 msgid "Triggered by"
 msgstr "Kích hoạt bởi"
 
 #: templates/problem/review.html:58
-#| msgid "Unknown"
 msgid "(unknown)"
 msgstr "(không rõ)"
 
 #: templates/problem/review.html:65
-#| msgid "View more"
 msgid "View run"
 msgstr "Xem lần chạy"
 
 #: templates/problem/review.html:71
-#| msgid "Templates"
 msgid "latest"
 msgstr "mới nhất"
 
@@ -11056,7 +11047,6 @@ msgid "It was superseded by"
 msgstr "Đã được thay thế bởi"
 
 #: templates/problem/review.html:98
-#| msgid "Reviewing problem statements"
 msgid "Review in progress…"
 msgstr "Đang xem xét…"
 
@@ -11069,7 +11059,6 @@ msgid "passed"
 msgstr ""
 
 #: templates/problem/review.html:104 templates/problem/review.html:112
-#| msgid "Skipped"
 msgid "skipped"
 msgstr "bỏ qua"
 
@@ -11082,35 +11071,28 @@ msgid "No checks ran."
 msgstr ""
 
 #: templates/problem/review.html:125
-#| msgid "hide results"
 msgid "Check results"
 msgstr "Kết quả kiểm tra"
 
 #: templates/problem/review.html:131
-#| msgid "Checker"
 msgid "Check"
 msgstr "Kiểm tra"
 
-#: templates/problem/review.html:175
-#| msgid "Show details"
-msgid "View details"
-msgstr "Xem chi tiết"
-
-#: templates/problem/review.html:189
+#: templates/problem/review.html:179
 msgid "AI-synthesized feedback"
 msgstr "Phản hồi tổng hợp bởi AI"
 
-#: templates/problem/review.html:198
+#: templates/problem/review.html:188
 msgid ""
 "Generating AI feedback… this will appear automatically when the run "
 "finishes."
 msgstr "Đang tạo phản hồi AI… nội dung sẽ tự hiện khi lần chạy kết thúc."
 
-#: templates/problem/review.html:203
+#: templates/problem/review.html:193
 msgid "All checks passed — no AI feedback needed."
 msgstr "Tất cả kiểm tra đã qua — không cần phản hồi AI."
 
-#: templates/problem/review.html:208
+#: templates/problem/review.html:198
 msgid "No AI feedback was produced for this run."
 msgstr "Lần chạy này không có phản hồi AI."
 
@@ -13567,6 +13549,24 @@ msgstr "Chọn tất cả"
 #: templates/widgets/sortable_formset.html:21
 msgid "No items yet."
 msgstr "Chưa có mục nào."
+
+#~ msgid "Checker correctness"
+#~ msgstr "Tính đúng đắn của checker"
+
+#~ msgid "Duplicate detection"
+#~ msgstr "Phát hiện trùng đề"
+
+#~ msgid "Solutions rubric"
+#~ msgstr "Rubric bài tham chiếu"
+
+#~ msgid "Time-limit headroom"
+#~ msgstr "Khoảng dư thời gian"
+
+#~ msgid "Validator runs clean"
+#~ msgstr "Validator chạy sạch"
+
+#~ msgid "View details"
+#~ msgstr "Xem chi tiết"
 
 #~ msgid "Public request is pending review."
 #~ msgstr "Yêu cầu công khai đang chờ duyệt."

--- a/templates/problem/review.html
+++ b/templates/problem/review.html
@@ -166,16 +166,6 @@
                 </td>
                 <td class="check-col-reason">
                   {{ cr.reason }}
-                {# Expandable raw payload — useful for admins debugging an LLM
-                   verdict, gated behind <details> so it doesn't crowd the row.
-                   `cr.details_json` is a JSONField (dict); rendering empty
-                   dicts/None is suppressed so passing rows stay clean. #}
-                  {% if cr.details_json %}
-                    <details class="check-details">
-                      <summary>{{ _("View details") }}</summary>
-                    <pre class="check-details-json">{{ cr.details_json | tojson(indent=2) }}</pre>
-                    </details>
-                  {% endif %}
                 </td>
               </tr>
             {% endfor %}


### PR DESCRIPTION
- Shorten check display_names (Artifacts, Checker, Duplicates, Solutions, Time limit, Validator) so single-word Vietnamese labels read naturally.
- Wrap display_names in gettext_lazy so they translate per-request.
- Localize artifacts_present missing-item tokens (statement, test data, checker, main AC source) — Vietnamese sessions no longer see raw English tokens inside translated strings.
- Accept ProblemData.generator and generator_script as test_data evidence — matches how the judge actually grades, fixes false-FAIL on aplusb-style problems that use a generator instead of a zip.
- Remove the per-check "View details" JSON expandable — debug output with no actionable info for authors, was cluttering the dashboard.