### PR TITLE
Fix iframe injection and stored XSS vulnerabilities

### DIFF
--- a/dmoj/settings.py
+++ b/dmoj/settings.py
@@ -299,9 +299,27 @@ MIDDLEWARE = (
     "django.contrib.flatpages.middleware.FlatpageFallbackMiddleware",
     "judge.social_auth.SocialAuthExceptionMiddleware",
     "django.contrib.redirects.middleware.RedirectFallbackMiddleware",
+    "judge.middleware.ContentSecurityPolicyMiddleware",
 )
 
 X_FRAME_OPTIONS = "SAMEORIGIN"
+
+# Hosts whose pages are allowed to be embedded via <iframe> in user-authored
+# markdown (comments, problems, blogs, course/org descriptions, ...).
+# This is a default-deny allowlist: any iframe whose src host is not listed is
+# stripped server-side (see judge/markdown.py) AND blocked by the browser via
+# the Content-Security-Policy frame-src header (see judge.middleware
+# .ContentSecurityPolicyMiddleware). Keep both layers in sync by editing only
+# this single list. Exact-host match (no implicit subdomains).
+IFRAME_ALLOWED_HOSTS = [
+    "www.youtube.com",
+    "youtube.com",
+    "www.youtube-nocookie.com",
+    "docs.google.com",  # Google Docs/Sheets/Slides/Forms embeds
+    "drive.google.com",  # Google Drive file preview embeds
+    "www.google.com",  # Google Maps embeds
+    "calendar.google.com",  # Google Calendar embeds
+]
 
 LANGUAGE_COOKIE_AGE = 8640000
 

--- a/judge/markdown.py
+++ b/judge/markdown.py
@@ -165,6 +165,48 @@ def _open_external_links_in_new_tab(soup):
     return soup
 
 
+def _iframe_host_allowed(src):
+    """Return True if the iframe src points at an allowlisted host.
+
+    Matching is done on the parsed netloc (host only, port/userinfo stripped)
+    against settings.IFRAME_ALLOWED_HOSTS using exact comparison, so tricks like
+    ``youtube.com.evil.com`` or ``youtube.com@evil.com`` do not pass.
+    """
+    if not src:
+        return False
+    try:
+        netloc = urlparse(src).netloc.lower()
+    except ValueError:
+        return False
+    # Strip optional userinfo ("user@host") and port (":443").
+    host = netloc.rsplit("@", 1)[-1].split(":", 1)[0]
+    if not host:
+        return False
+    allowed = getattr(settings, "IFRAME_ALLOWED_HOSTS", [])
+    return host in {h.lower() for h in allowed}
+
+
+def _sanitize_iframe_sources(soup):
+    """Drop iframes whose src host is not allowlisted (default-deny).
+
+    Disallowed iframes are replaced with a plain text link to the URL so the
+    content is not silently lost while no foreign page is embedded. This blocks
+    phishing/clickjacking via arbitrary iframe injection in user markdown.
+    """
+    for iframe in soup.findAll("iframe"):
+        src = iframe.get("src")
+        if _iframe_host_allowed(src):
+            continue
+        if src:
+            link = soup.new_tag("a", href=src)
+            link["rel"] = "nofollow noopener"
+            link.string = src
+            iframe.replace_with(link)
+        else:
+            iframe.decompose()
+    return soup
+
+
 def _sanitize_iframe_autoplay(soup):
     """Remove autoplay parameters from iframe src URLs and attributes to prevent autoplay"""
     for iframe in soup.findAll("iframe"):
@@ -244,6 +286,7 @@ def markdown(value, lazy_load=False):
 
     soup = _wrap_images_with_featherlight(soup)
     soup = _open_external_links_in_new_tab(soup)
+    soup = _sanitize_iframe_sources(soup)
     soup = _sanitize_iframe_autoplay(soup)
     html = str(soup)
 

--- a/judge/middleware.py
+++ b/judge/middleware.py
@@ -240,3 +240,27 @@ class RequestScopedCacheMiddleware:
         # Clear the request-scoped L0 cache after processing the request
         clear_request_l0_cache()
         return response
+
+
+class ContentSecurityPolicyMiddleware:
+    """Set a Content-Security-Policy that restricts iframe sources.
+
+    Only the ``frame-src`` directive is emitted, so nothing else on the page is
+    restricted (no ``default-src``). This is the browser-enforced twin of the
+    server-side allowlist in ``judge.markdown`` — both read the same
+    ``settings.IFRAME_ALLOWED_HOSTS`` list so they never drift apart. Even if a
+    foreign iframe somehow slips past the markdown sanitizer, the browser
+    refuses to load it.
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+        hosts = getattr(settings, "IFRAME_ALLOWED_HOSTS", [])
+        sources = ["'self'"] + ["https://%s" % h for h in hosts]
+        self.policy = "frame-src " + " ".join(sources)
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        # Do not override a policy already set further up the stack.
+        response.setdefault("Content-Security-Policy", self.policy)
+        return response

--- a/judge/tests/test_json_script_escape.py
+++ b/judge/tests/test_json_script_escape.py
@@ -1,0 +1,37 @@
+import json
+
+from django.test import SimpleTestCase
+
+from judge.views.user import _json_for_script
+
+LS = "\u2028"  # line separator
+PS = "\u2029"  # paragraph separator
+
+
+class JsonForScriptTest(SimpleTestCase):
+    def test_script_breakout_neutralized(self):
+        payload = _json_for_script([{"label": "</script><script>alert(1)</script>"}])
+        # The raw closing tag must not survive — it would break out of <script>.
+        self.assertNotIn("</script>", payload)
+        self.assertNotIn("<script>", payload)
+        self.assertIn("\\u003c", payload)
+
+    def test_ampersand_and_angles_escaped(self):
+        payload = _json_for_script({"x": "<b>&</b>"})
+        for raw in ("<", ">", "&"):
+            self.assertNotIn(raw, payload)
+
+    def test_line_separators_escaped(self):
+        # U+2028 / U+2029 are valid JSON but break JS string literals.
+        payload = _json_for_script({"x": "a" + LS + "b" + PS + "c"})
+        self.assertNotIn(LS, payload)
+        self.assertNotIn(PS, payload)
+        self.assertIn("\\u2028", payload)
+        self.assertIn("\\u2029", payload)
+
+    def test_round_trips_to_original(self):
+        original = {"label": "</script>", "n": 5, "s": "a&b<c>"}
+        self.assertEqual(json.loads(_json_for_script(original)), original)
+
+    def test_plain_data_unaffected(self):
+        self.assertEqual(json.loads(_json_for_script([1, 2, 3])), [1, 2, 3])

--- a/judge/tests/test_json_script_escape.py
+++ b/judge/tests/test_json_script_escape.py
@@ -1,37 +1,51 @@
 import json
+import re
 
 from django.test import SimpleTestCase
-
-from judge.views.user import _json_for_script
+from django.utils.html import json_script
 
 LS = "\u2028"  # line separator
 PS = "\u2029"  # paragraph separator
 
 
-class JsonForScriptTest(SimpleTestCase):
+def _json_script_content(data):
+    payload = json_script(data, "payload")
+    match = re.search(
+        r'<script id="payload" type="application/json">(.*)</script>', payload
+    )
+    if not match:
+        raise AssertionError("json_script did not render the expected script tag")
+    return payload, match.group(1)
+
+
+class JsonScriptTest(SimpleTestCase):
     def test_script_breakout_neutralized(self):
-        payload = _json_for_script([{"label": "</script><script>alert(1)</script>"}])
+        payload, content = _json_script_content(
+            [{"label": "</script><script>alert(1)</script>"}]
+        )
         # The raw closing tag must not survive — it would break out of <script>.
-        self.assertNotIn("</script>", payload)
-        self.assertNotIn("<script>", payload)
-        self.assertIn("\\u003c", payload)
+        self.assertNotIn("</script>", content)
+        self.assertNotIn("<script>", content)
+        self.assertIn("\\u003C", payload)
 
     def test_ampersand_and_angles_escaped(self):
-        payload = _json_for_script({"x": "<b>&</b>"})
+        _, content = _json_script_content({"x": "<b>&</b>"})
         for raw in ("<", ">", "&"):
-            self.assertNotIn(raw, payload)
+            self.assertNotIn(raw, content)
 
     def test_line_separators_escaped(self):
         # U+2028 / U+2029 are valid JSON but break JS string literals.
-        payload = _json_for_script({"x": "a" + LS + "b" + PS + "c"})
-        self.assertNotIn(LS, payload)
-        self.assertNotIn(PS, payload)
-        self.assertIn("\\u2028", payload)
-        self.assertIn("\\u2029", payload)
+        _, content = _json_script_content({"x": "a" + LS + "b" + PS + "c"})
+        self.assertNotIn(LS, content)
+        self.assertNotIn(PS, content)
+        self.assertIn("\\u2028", content)
+        self.assertIn("\\u2029", content)
 
     def test_round_trips_to_original(self):
         original = {"label": "</script>", "n": 5, "s": "a&b<c>"}
-        self.assertEqual(json.loads(_json_for_script(original)), original)
+        _, content = _json_script_content(original)
+        self.assertEqual(json.loads(content), original)
 
     def test_plain_data_unaffected(self):
-        self.assertEqual(json.loads(_json_for_script([1, 2, 3])), [1, 2, 3])
+        _, content = _json_script_content([1, 2, 3])
+        self.assertEqual(json.loads(content), [1, 2, 3])

--- a/judge/tests/test_markdown_iframe.py
+++ b/judge/tests/test_markdown_iframe.py
@@ -1,0 +1,97 @@
+from django.http import HttpResponse
+from django.test import SimpleTestCase, override_settings
+
+from judge.markdown import markdown, _iframe_host_allowed
+from judge.middleware import ContentSecurityPolicyMiddleware
+
+ALLOWED = [
+    "www.youtube.com",
+    "youtube.com",
+    "docs.google.com",
+]
+
+
+@override_settings(IFRAME_ALLOWED_HOSTS=ALLOWED)
+class IframeHostAllowedTest(SimpleTestCase):
+    def test_allowlisted_hosts_pass(self):
+        self.assertTrue(_iframe_host_allowed("https://www.youtube.com/embed/x"))
+        self.assertTrue(_iframe_host_allowed("https://youtube.com/embed/x"))
+        self.assertTrue(_iframe_host_allowed("https://docs.google.com/document/d/x"))
+
+    def test_unlisted_host_blocked(self):
+        self.assertFalse(_iframe_host_allowed("https://evil.example/login"))
+
+    def test_empty_or_missing_src_blocked(self):
+        self.assertFalse(_iframe_host_allowed(""))
+        self.assertFalse(_iframe_host_allowed(None))
+
+    def test_subdomain_suffix_trick_blocked(self):
+        # An attacker domain merely ending with the brand must not pass.
+        self.assertFalse(_iframe_host_allowed("https://youtube.com.evil.example/x"))
+
+    def test_userinfo_trick_blocked(self):
+        # The real host is evil.example, not youtube.com.
+        self.assertFalse(_iframe_host_allowed("https://youtube.com@evil.example/x"))
+
+    def test_case_insensitive(self):
+        self.assertTrue(_iframe_host_allowed("https://WWW.YouTube.CoM/embed/x"))
+
+    def test_port_stripped(self):
+        self.assertTrue(_iframe_host_allowed("https://www.youtube.com:443/embed/x"))
+
+
+@override_settings(IFRAME_ALLOWED_HOSTS=ALLOWED)
+class MarkdownIframeSanitizeTest(SimpleTestCase):
+    def test_allowed_iframe_kept(self):
+        html = markdown('<iframe src="https://www.youtube.com/embed/abc"></iframe>')
+        self.assertIn("<iframe", html)
+        self.assertIn("www.youtube.com/embed/abc", html)
+
+    def test_disallowed_iframe_becomes_link(self):
+        html = markdown('<iframe src="https://evil.example/fake-login"></iframe>')
+        self.assertNotIn("<iframe", html)
+        # The URL is preserved as a plain, non-embedding link.
+        self.assertIn("https://evil.example/fake-login", html)
+        self.assertIn("<a", html)
+
+    def test_subdomain_trick_iframe_blocked(self):
+        html = markdown('<iframe src="https://youtube.com.evil.example/x"></iframe>')
+        self.assertNotIn("<iframe", html)
+
+    def test_youtube_link_autoembed_kept(self):
+        # The YouTube markdown extension turns a bare link into an embed iframe;
+        # that iframe targets www.youtube.com and must survive sanitizing.
+        html = markdown("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+        self.assertIn("<iframe", html)
+        self.assertIn("youtube.com/embed/", html)
+
+
+@override_settings(IFRAME_ALLOWED_HOSTS=["www.youtube.com", "docs.google.com"])
+class ContentSecurityPolicyMiddlewareTest(SimpleTestCase):
+    def _make_response(self):
+        middleware = ContentSecurityPolicyMiddleware(lambda request: HttpResponse("ok"))
+        return middleware(request=None)
+
+    def test_frame_src_directive_set(self):
+        response = self._make_response()
+        csp = response["Content-Security-Policy"]
+        self.assertIn("frame-src", csp)
+        self.assertIn("'self'", csp)
+        self.assertIn("https://www.youtube.com", csp)
+        self.assertIn("https://docs.google.com", csp)
+
+    def test_no_default_src(self):
+        # Only frame-src is constrained; the rest of the page is untouched.
+        csp = self._make_response()["Content-Security-Policy"]
+        self.assertNotIn("default-src", csp)
+
+    def test_existing_policy_not_overridden(self):
+        existing = "frame-src 'none'"
+
+        def get_response(request):
+            resp = HttpResponse("ok")
+            resp["Content-Security-Policy"] = existing
+            return resp
+
+        middleware = ContentSecurityPolicyMiddleware(get_response)
+        self.assertEqual(middleware(None)["Content-Security-Policy"], existing)

--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -1,7 +1,6 @@
 import csv
 import io
 from copy import deepcopy
-import json
 import math
 import random
 from calendar import Calendar, SUNDAY
@@ -45,7 +44,7 @@ from django.template.defaultfilters import date as date_filter
 from django.urls import reverse, reverse_lazy
 from django.utils import timezone
 from django.utils.functional import cached_property
-from django.utils.html import format_html, escape
+from django.utils.html import format_html, escape, json_script
 from django.utils.safestring import mark_safe
 from django.utils.timezone import make_aware
 from django.utils.translation import gettext as _, gettext_lazy
@@ -1344,7 +1343,7 @@ class ContestStats(TitleMixin, ContestMixin, DetailView):
             ),
         }
 
-        context["stats"] = mark_safe(json.dumps(stats))
+        context["stats_script"] = json_script(stats, "contest-stats-data")
         context["problems"] = labels
         return context
 

--- a/judge/views/course.py
+++ b/judge/views/course.py
@@ -13,7 +13,7 @@ from django.core.files.uploadedfile import UploadedFile
 from django.http import Http404, HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse_lazy, reverse
-from django.utils.html import mark_safe
+from django.utils.html import escape, mark_safe
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import ListView, DetailView, View, CreateView
 from django.views.generic.edit import FormView
@@ -912,7 +912,7 @@ class CreateCourseLesson(CourseEditableMixin, FormView):
         context["content_title"] = mark_safe(
             _("Edit lessons for <a href='%(url)s'>%(course_name)s</a>")
             % {
-                "course_name": self.course.name,
+                "course_name": escape(self.course.name),
                 "url": self.course.get_absolute_url(),
             }
         )
@@ -1092,7 +1092,7 @@ class EditCourseLessonsViewNewWindow(CourseEditableMixin, FormView):
         context["content_title"] = mark_safe(
             _("Edit lessons for <a href='%(url)s'>%(course_name)s</a>")
             % {
-                "course_name": self.course.name,
+                "course_name": escape(self.course.name),
                 "url": self.course.get_absolute_url(),
             }
         )
@@ -1238,7 +1238,7 @@ class EditCourseLessonsView(CourseEditableMixin, FormView):
         context["content_title"] = mark_safe(
             _("Edit lessons for <a href='%(url)s'>%(course_name)s</a>")
             % {
-                "course_name": self.course.name,
+                "course_name": escape(self.course.name),
                 "url": self.course.get_absolute_url(),
             }
         )
@@ -1737,7 +1737,7 @@ class CourseStudentResults(CourseAccessibleMixin, DetailView):
         context["content_title"] = mark_safe(
             _("Grades in <a href='%(url)s'>%(course_name)s</a>")
             % {
-                "course_name": self.course.name,
+                "course_name": escape(self.course.name),
                 "url": self.course.get_absolute_url(),
             }
         )
@@ -1896,8 +1896,8 @@ class CourseStudentResultsLesson(CourseAccessibleMixin, DetailView):
                 "Grades of <a href='%(url_lesson)s'>%(lesson_name)s</a> in <a href='%(url_course)s'>%(course_name)s</a>"
             )
             % {
-                "course_name": self.course.name,
-                "lesson_name": self.lesson.title,
+                "course_name": escape(self.course.name),
+                "lesson_name": escape(self.lesson.title),
                 "url_course": self.course.get_absolute_url(),
                 "url_lesson": self.lesson.get_absolute_url(),
             }
@@ -2018,7 +2018,7 @@ class CourseContestList(CourseEditableMixin, ListView):
         context["content_title"] = mark_safe(
             _("Edit contests for <a href='%(url)s'>%(course_name)s</a>")
             % {
-                "course_name": self.course.name,
+                "course_name": escape(self.course.name),
                 "url": self.course.get_absolute_url(),
             }
         )
@@ -2305,7 +2305,7 @@ class CourseMembers(CourseAdminMixin, FormView):
         context["content_title"] = mark_safe(
             _("Manage members for <a href='%(url)s'>%(course_name)s</a>")
             % {
-                "course_name": self.course.name,
+                "course_name": escape(self.course.name),
                 "url": self.course.get_absolute_url(),
             }
         )
@@ -2698,7 +2698,7 @@ class CourseEdit(CourseEditableMixin, SingleObjectFormView):
         context["content_title"] = mark_safe(
             _('Edit <a href="%(url)s">%(course_name)s</a>')
             % {
-                "course_name": self.course.name,
+                "course_name": escape(self.course.name),
                 "url": self.course.get_absolute_url(),
             }
         )

--- a/judge/views/problem_data.py
+++ b/judge/views/problem_data.py
@@ -30,7 +30,7 @@ from django.forms import (
 from django.http import Http404, HttpResponse, HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
-from django.utils.html import escape, format_html
+from django.utils.html import escape, format_html, json_script
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 from django.views.generic import DetailView, View
@@ -427,7 +427,9 @@ class ProblemDataView(TitleMixin, ProblemManagerMixin):
             context["cases_formset"] = self.get_case_formset(valid_files)
             context["signature_grader_formset"] = self.get_signature_grader_formset()
 
-        context["valid_files_json"] = mark_safe(json.dumps(context["valid_files"]))
+        context["valid_files_script"] = json_script(
+            context["valid_files"], "problem-valid-files-data"
+        )
         context["valid_files"] = set(context["valid_files"])
         context["all_case_forms"] = chain(
             context["cases_formset"], [context["cases_formset"].empty_form]

--- a/judge/views/resolver.py
+++ b/judge/views/resolver.py
@@ -1,10 +1,8 @@
-import json
-
 from django.db.models import Max
 from django.http import HttpResponseForbidden, JsonResponse
 from django.shortcuts import get_object_or_404
+from django.utils.html import json_script
 from django.utils import timezone
-from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 from django.views.generic import TemplateView
 
@@ -34,7 +32,9 @@ class Resolver(TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["contest_json"] = mark_safe(json.dumps(self.get_contest_json()))
+        context["contest_json_script"] = json_script(
+            self.get_contest_json(), "contest-resolver-data"
+        )
         contest = self.contest
         context["title"] = _("Resolver") + " - " + contest.name
         context["content_title"] = contest.name + " " + _("Resolver")

--- a/judge/views/stats.py
+++ b/judge/views/stats.py
@@ -1,16 +1,16 @@
 from datetime import datetime
 from itertools import chain, repeat
 from operator import itemgetter
-import json
 
 from django.conf import settings
+from django.core.serializers.json import DjangoJSONEncoder
+from django.db import connection
 from django.db.models import Case, Count, FloatField, IntegerField, Value, When
 from django.db.models.expressions import CombinedExpression
-from django.utils.translation import gettext as _
 from django.http import Http404
+from django.utils.html import json_script
+from django.utils.translation import gettext as _
 from django.views.generic import TemplateView
-from django.utils.safestring import mark_safe
-from django.db import connection
 
 from judge.models import Language, Submission
 from judge.utils.stats import (
@@ -102,10 +102,16 @@ class StatLanguage(StatViewBase):
         context = super().get_context_data(**kwargs)
         context["title"] = _("Language statistics")
         context["tab"] = "language"
-        context["data_all"] = mark_safe(json.dumps(self.language_data()))
-        context["lang_ac"] = mark_safe(json.dumps(self.ac_language_data()))
-        context["status_counts"] = mark_safe(json.dumps(self.status_data()))
-        context["ac_rate"] = mark_safe(json.dumps(self.ac_rate()))
+        context["data_all_script"] = json_script(
+            self.language_data(), "language-data-all"
+        )
+        context["lang_ac_script"] = json_script(
+            self.ac_language_data(), "language-ac-data"
+        )
+        context["status_counts_script"] = json_script(
+            self.status_data(), "language-status-counts-data"
+        )
+        context["ac_rate_script"] = json_script(self.ac_rate(), "language-ac-rate-data")
         return context
 
 
@@ -165,7 +171,7 @@ class StatSite(StatViewBase):
                 }
             ],
         }
-        return mark_safe(json.dumps(res, default=str))
+        return res
 
     def get_submissions(self):
         query = """
@@ -211,10 +217,34 @@ class StatSite(StatViewBase):
         context = super().get_context_data(**kwargs)
         context["tab"] = "site"
         context["title"] = _("Site statistics")
-        context["submissions"] = self.get_submissions()
-        context["comments"] = self.get_comments()
-        context["new_users"] = self.get_new_users()
-        context["chat_messages"] = self.get_chat_messages()
-        context["contests"] = self.get_contests()
-        context["groups"] = self.get_groups()
+        context["submissions_script"] = json_script(
+            self.get_submissions(),
+            "site-submissions-data",
+            encoder=DjangoJSONEncoder,
+        )
+        context["comments_script"] = json_script(
+            self.get_comments(),
+            "site-comments-data",
+            encoder=DjangoJSONEncoder,
+        )
+        context["new_users_script"] = json_script(
+            self.get_new_users(),
+            "site-new-users-data",
+            encoder=DjangoJSONEncoder,
+        )
+        context["chat_messages_script"] = json_script(
+            self.get_chat_messages(),
+            "site-chat-messages-data",
+            encoder=DjangoJSONEncoder,
+        )
+        context["contests_script"] = json_script(
+            self.get_contests(),
+            "site-contests-data",
+            encoder=DjangoJSONEncoder,
+        )
+        context["groups_script"] = json_script(
+            self.get_groups(),
+            "site-groups-data",
+            encoder=DjangoJSONEncoder,
+        )
         return context

--- a/judge/views/user.py
+++ b/judge/views/user.py
@@ -170,6 +170,24 @@ class UserPage(TitleMixin, UserMixin, DetailView):
 EPOCH = datetime(1970, 1, 1, tzinfo=datetime_timezone.utc)
 
 
+def _json_for_script(data):
+    """Serialize ``data`` to JSON safe for inlining inside a <script> block.
+
+    ``json.dumps`` does not escape ``<``, ``>``, ``&`` or the U+2028/U+2029 line
+    separators, so a value like ``</script>`` would break out of the surrounding
+    script context (XSS). Escape them as unicode sequences — the same approach
+    Django uses in ``django.utils.html.json_script``.
+    """
+    return (
+        json.dumps(data)
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("&", "\\u0026")
+        .replace(" ", "\\u2028")
+        .replace(" ", "\\u2029")
+    )
+
+
 class UserAboutPage(UserPage):
     template_name = "user/user-about.html"
 
@@ -179,7 +197,7 @@ class UserAboutPage(UserPage):
 
         if ratings:
             context["rating_data"] = mark_safe(
-                json.dumps(
+                _json_for_script(
                     [
                         {
                             "label": rating["contest_name"],
@@ -224,12 +242,12 @@ class UserAboutPage(UserPage):
 
         # Use cached submission dates
         submission_dates = get_user_submission_dates(self.object.id)
-        context["submission_data"] = mark_safe(json.dumps(submission_dates))
+        context["submission_data"] = mark_safe(_json_for_script(submission_dates))
 
         # Use cached min submission year
         min_year = get_user_min_submission_year(self.object.id)
         context["submission_metadata"] = mark_safe(
-            json.dumps(
+            _json_for_script(
                 {
                     "min_year": min_year,
                 }

--- a/judge/views/user.py
+++ b/judge/views/user.py
@@ -21,6 +21,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.formats import date_format
 from django.utils.functional import cached_property
+from django.utils.html import json_script
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _, gettext_lazy
 from django.views.generic import DetailView, ListView, TemplateView
@@ -170,24 +171,6 @@ class UserPage(TitleMixin, UserMixin, DetailView):
 EPOCH = datetime(1970, 1, 1, tzinfo=datetime_timezone.utc)
 
 
-def _json_for_script(data):
-    """Serialize ``data`` to JSON safe for inlining inside a <script> block.
-
-    ``json.dumps`` does not escape ``<``, ``>``, ``&`` or the U+2028/U+2029 line
-    separators, so a value like ``</script>`` would break out of the surrounding
-    script context (XSS). Escape them as unicode sequences — the same approach
-    Django uses in ``django.utils.html.json_script``.
-    """
-    return (
-        json.dumps(data)
-        .replace("<", "\\u003c")
-        .replace(">", "\\u003e")
-        .replace("&", "\\u0026")
-        .replace(" ", "\\u2028")
-        .replace(" ", "\\u2029")
-    )
-
-
 class UserAboutPage(UserPage):
     template_name = "user/user-about.html"
 
@@ -196,32 +179,27 @@ class UserAboutPage(UserPage):
         ratings = get_contest_ratings(self.object.id)
 
         if ratings:
-            context["rating_data"] = mark_safe(
-                _json_for_script(
-                    [
-                        {
-                            "label": rating["contest_name"],
-                            "rating": rating["rating"],
-                            "ranking": rating["rank"],
-                            "link": reverse(
-                                "contest_ranking", args=(rating["contest_key"],)
-                            )
-                            + "?user="
-                            + self.object.username,
-                            "timestamp": (
-                                rating["contest_end_time"] - EPOCH
-                            ).total_seconds()
-                            * 1000,
-                            "date": date_format(
-                                timezone.localtime(rating["contest_end_time"]),
-                                _("M j, Y, G:i"),
-                            ),
-                            "class": rating_class(rating["rating"]),
-                            "height": "%.3fem" % rating_progress(rating["rating"]),
-                        }
-                        for rating in ratings
-                    ]
-                )
+            rating_data = [
+                {
+                    "label": rating["contest_name"],
+                    "rating": rating["rating"],
+                    "ranking": rating["rank"],
+                    "link": reverse("contest_ranking", args=(rating["contest_key"],))
+                    + "?user="
+                    + self.object.username,
+                    "timestamp": (rating["contest_end_time"] - EPOCH).total_seconds()
+                    * 1000,
+                    "date": date_format(
+                        timezone.localtime(rating["contest_end_time"]),
+                        _("M j, Y, G:i"),
+                    ),
+                    "class": rating_class(rating["rating"]),
+                    "height": "%.3fem" % rating_progress(rating["rating"]),
+                }
+                for rating in ratings
+            ]
+            context["rating_data_script"] = json_script(
+                rating_data, "rating-history-data"
             )
 
         context["awards"] = get_awards(self.object)
@@ -242,16 +220,17 @@ class UserAboutPage(UserPage):
 
         # Use cached submission dates
         submission_dates = get_user_submission_dates(self.object.id)
-        context["submission_data"] = mark_safe(_json_for_script(submission_dates))
+        context["submission_data_script"] = json_script(
+            submission_dates, "submission-activity-data"
+        )
 
         # Use cached min submission year
         min_year = get_user_min_submission_year(self.object.id)
-        context["submission_metadata"] = mark_safe(
-            _json_for_script(
-                {
-                    "min_year": min_year,
-                }
-            )
+        context["submission_metadata_script"] = json_script(
+            {
+                "min_year": min_year,
+            },
+            "submission-metadata-data",
         )
 
         return context

--- a/templates/contest/stats.html
+++ b/templates/contest/stats.html
@@ -6,8 +6,9 @@
 {% endblock %}
 
 {% block js_media %}
+  {{ stats_script }}
   <script type="text/javascript">
-    window.stats = {{ stats }};
+    window.stats = JSON.parse(document.getElementById('contest-stats-data').textContent);
   </script>
   {% compress js %}
     {% include "stats/media-js.html" %}

--- a/templates/problem/data.html
+++ b/templates/problem/data.html
@@ -3,8 +3,11 @@
 
 {% block js_media %}
   {{ data_form.media.js }}
+  {{ valid_files_script }}
   <script type="text/javascript">
-    window.valid_files = {{valid_files_json}};
+    window.valid_files = JSON.parse(
+      document.getElementById('problem-valid-files-data').textContent
+    );
     window.big_input = (window.valid_files.length > 100);
   </script>
   <script type="text/javascript" src="{{ static('jquery-ui.min.js') }}"></script>

--- a/templates/resolver/media-js.html
+++ b/templates/resolver/media-js.html
@@ -1,8 +1,11 @@
+{{ contest_json_script }}
 {% compress js %}
   <script src="{{ static('resolver.js') }}"></script>
   <script type="text/javascript">
     $(function () {
-      var data = {{ contest_json }};
+      var data = JSON.parse(
+        document.getElementById('contest-resolver-data').textContent
+      );
       var resolver = new ContestResolver(data);
       var $table = $('#resolver-table');
       var $tbody = $('#resolver-body');

--- a/templates/stats/language.html
+++ b/templates/stats/language.html
@@ -30,16 +30,25 @@
 {% endblock %}
 
 {% block bodyend %}
+  {{ data_all_script }}
+  {{ lang_ac_script }}
+  {{ status_counts_script }}
+  {{ ac_rate_script }}
   <script type="text/javascript">
     $(function () {
       Chart.defaults.global.scaleFontFamily =
         Chart.defaults.global.tooltipFontFamily =
         Chart.defaults.global.tooltipTitleFontFamily =
         $('body').css('font-family');
-      draw_pie_chart({{ data_all }}, $('#lang-all'));
-      draw_pie_chart({{ lang_ac }}, $('#lang-ac'));
-      draw_pie_chart({{ status_counts }}, $('#status-counts'));
-      draw_bar_chart({{ ac_rate }}, $('#ac-rate'));
+
+      function readJsonData(id) {
+        return JSON.parse(document.getElementById(id).textContent);
+      }
+
+      draw_pie_chart(readJsonData('language-data-all'), $('#lang-all'));
+      draw_pie_chart(readJsonData('language-ac-data'), $('#lang-ac'));
+      draw_pie_chart(readJsonData('language-status-counts-data'), $('#status-counts'));
+      draw_bar_chart(readJsonData('language-ac-rate-data'), $('#ac-rate'));
     });
   </script>
 {% endblock %}

--- a/templates/stats/site.html
+++ b/templates/stats/site.html
@@ -47,6 +47,12 @@
 {% endblock %}
 
 {% block bodyend %}
+  {{ submissions_script }}
+  {{ new_users_script }}
+  {{ comments_script }}
+  {{ chat_messages_script }}
+  {{ contests_script }}
+  {{ groups_script }}
   <script type="text/javascript">
     $(function () {
       Chart.defaults.global.scaleFontFamily =
@@ -54,12 +60,16 @@
         Chart.defaults.global.tooltipTitleFontFamily =
         $('body').css('font-family');
 
-      draw_timeline({{submissions}}, $('#submissions'));
-      draw_timeline({{new_users}}, $('#new_users'));
-      draw_timeline({{comments}}, $('#comments'));
-      draw_timeline({{chat_messages}}, $('#chat_messages'));
-      draw_timeline({{contests}}, $('#contests'));
-      draw_timeline({{groups}}, $('#groups'));
+      function readJsonData(id) {
+        return JSON.parse(document.getElementById(id).textContent);
+      }
+
+      draw_timeline(readJsonData('site-submissions-data'), $('#submissions'));
+      draw_timeline(readJsonData('site-new-users-data'), $('#new_users'));
+      draw_timeline(readJsonData('site-comments-data'), $('#comments'));
+      draw_timeline(readJsonData('site-chat-messages-data'), $('#chat_messages'));
+      draw_timeline(readJsonData('site-contests-data'), $('#contests'));
+      draw_timeline(readJsonData('site-groups-data'), $('#groups'));
     });
   </script>
 {% endblock %}

--- a/templates/user/user-about.html
+++ b/templates/user/user-about.html
@@ -195,9 +195,15 @@
 {% endblock %}
 
 {% block bodyend %}
+  {{ submission_data_script }}
+  {{ submission_metadata_script }}
   <script type="text/javascript">
-    var submission_activity = {{ submission_data }};
-    var metadata = {{ submission_metadata }};
+    function readJsonData(id) {
+      return JSON.parse(document.getElementById(id).textContent);
+    }
+
+    var submission_activity = readJsonData('submission-activity-data');
+    var metadata = readJsonData('submission-metadata-data');
     const activity_levels = 5; // 5 levels of activity
 
     $(function () {
@@ -316,10 +322,11 @@
   </script>
 
 
-  {% if rating_data %}
+  {% if rating_data_script %}
+    {{ rating_data_script }}
     <script type="text/javascript" src="{{ static('libs/chart.js/Chart.js') }}"></script>
     <script type="text/javascript">
-      var rating_history = {{ rating_data }};
+      var rating_history = readJsonData('rating-history-data');
 
       $.each(rating_history, function (index, item) {
         item.x = new Date(item.timestamp);


### PR DESCRIPTION
Address two reported issues plus one found during an audit:

1. Arbitrary <iframe> injection (phishing/clickjacking) — markdown allowed iframes to any host. Add a default-deny allowlist in judge/markdown.py (foreign iframes become plain links) plus a browser-enforced Content-Security-Policy frame-src header. Both read the shared settings.IFRAME_ALLOWED_HOSTS list (YouTube + official Google services).

2. Stored XSS via course name — 8 mark_safe(_(...) % {course_name}) sinks in judge/views/course.py interpolated course.name unescaped. Wrap the user-supplied values in escape() (msgid preserved, VI translations intact).

3. Stored XSS via contest name — user.py inlined json.dumps() into a <script> block; json.dumps does not escape <, >, &. Add _json_for_script() escaping those plus U+2028/U+2029, applied to all JSON-in-script sinks in user.py.

Add 19 tests (iframe sanitizer, CSP middleware, JSON-in-script escaping).