### PR TITLE
Fix N+1 queries in quiz grading views

### DIFF
--- a/judge/tests/test_quiz_nplus1.py
+++ b/judge/tests/test_quiz_nplus1.py
@@ -1,0 +1,106 @@
+"""Regression tests guarding against N+1 queries in the quiz grading views.
+
+These assert that the number of queries touching the QuizAnswer table does NOT
+grow as more attempts are listed — i.e. the per-attempt `has_ungraded_essays`
+flag must be computed with a single batched query, not one query per attempt.
+
+Currently RED: it fails against the per-attempt `.exists()` loop in
+GradingDashboard / QuizGradingTab, and turns GREEN once that loop is replaced
+with a single batched lookup.
+"""
+
+from django.contrib.auth.models import User
+from django.db import connection
+from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
+
+from judge.models import Language, Profile
+from judge.models.quiz import (
+    Quiz,
+    QuizAnswer,
+    QuizAttempt,
+    QuizQuestion,
+    QuizQuestionAssignment,
+)
+
+ANSWER_TABLE = QuizAnswer._meta.db_table
+
+
+class GradingDashboardNPlusOneTest(TestCase):
+    fixtures = ["language_small"]
+
+    def setUp(self):
+        lang = Language.objects.first()
+
+        # Superuser views the dashboard (sees every submitted attempt).
+        self.admin = User.objects.create_superuser("quizadmin", "a@a.com", "pw")
+        Profile.objects.get_or_create(user=self.admin, defaults={"language": lang})
+
+        # A single student owns all attempts, so per-user template lookups
+        # (gravatar / link_user) stay constant and don't confound the count.
+        student_user = User.objects.create_user("student", "s@s.com", "pw")
+        self.student, _ = Profile.objects.get_or_create(
+            user=student_user, defaults={"language": lang}
+        )
+
+        self.essay = QuizQuestion.objects.create(
+            question_type="ES",
+            title="Essay",
+            content="Explain",
+            correct_answers=None,
+        )
+        self.quiz = Quiz.objects.create(code="nplus1quiz", title="N+1 Quiz")
+        QuizQuestionAssignment.objects.create(
+            quiz=self.quiz, question=self.essay, points=10, order=1
+        )
+
+        self.client.force_login(self.admin)
+
+    def _add_attempt(self, n):
+        """A submitted attempt with one ungraded (graded_at=None) essay answer."""
+        attempt = QuizAttempt.objects.create(
+            user=self.student,
+            quiz=self.quiz,
+            attempt_number=n,
+            is_submitted=True,
+        )
+        QuizAnswer.objects.create(
+            attempt=attempt,
+            question=self.essay,
+            answer="an essay answer",
+            graded_at=None,
+        )
+        return attempt
+
+    def _answer_query_count(self, url):
+        with CaptureQueriesContext(connection) as ctx:
+            resp = self.client.get(url)
+            self.assertEqual(resp.status_code, 200)
+        return sum(1 for q in ctx.captured_queries if ANSWER_TABLE in q["sql"])
+
+    def _assert_constant(self, url, label):
+        # one attempt currently on the dashboard
+        self._add_attempt(1)
+        base = self._answer_query_count(url)
+
+        # grow to five attempts
+        for n in range(2, 6):
+            self._add_attempt(n)
+        grown = self._answer_query_count(url)
+
+        self.assertEqual(
+            grown,
+            base,
+            f"N+1 in {label}: {base} {ANSWER_TABLE} queries with 1 attempt, "
+            f"{grown} with 5. The per-attempt has_ungraded_essays check must be "
+            f"batched into a single query.",
+        )
+
+    def test_grading_dashboard_no_nplus1(self):
+        self._assert_constant(reverse("grading_dashboard"), "GradingDashboard")
+
+    def test_quiz_grade_tab_no_nplus1(self):
+        # QuizGradingTab is the per-quiz twin of the dashboard (same loop).
+        url = reverse("quiz_grade_tab", args=[self.quiz.code])
+        self._assert_constant(url, "QuizGradingTab")

--- a/judge/views/quiz.py
+++ b/judge/views/quiz.py
@@ -2442,12 +2442,19 @@ class GradingDashboard(
             except Profile.DoesNotExist:
                 pass
 
-        # Add has_ungraded_essays flag to each attempt
-        for attempt in context["attempts"]:
-            attempt.has_ungraded_essays = attempt.answers.filter(
+        # Compute has_ungraded_essays in ONE batched query instead of one
+        # .exists() per attempt (which was an N+1). Collect the ids of attempts
+        # on this page that still have an ungraded essay answer, then flag each.
+        page_attempts = list(context["attempts"])
+        ungraded_attempt_ids = set(
+            QuizAnswer.objects.filter(
+                attempt_id__in=[a.id for a in page_attempts],
                 question__question_type="ES",
                 graded_at__isnull=True,
-            ).exists()
+            ).values_list("attempt_id", flat=True)
+        )
+        for attempt in page_attempts:
+            attempt.has_ungraded_essays = attempt.id in ungraded_attempt_ids
 
         context["page_type"] = "grading"
 
@@ -3030,12 +3037,19 @@ class QuizGradingTab(
             except Profile.DoesNotExist:
                 pass
 
-        # Add has_ungraded_essays flag to each attempt
-        for attempt in context["attempts"]:
-            attempt.has_ungraded_essays = attempt.answers.filter(
+        # Compute has_ungraded_essays in ONE batched query instead of one
+        # .exists() per attempt (which was an N+1). Collect the ids of attempts
+        # on this page that still have an ungraded essay answer, then flag each.
+        page_attempts = list(context["attempts"])
+        ungraded_attempt_ids = set(
+            QuizAnswer.objects.filter(
+                attempt_id__in=[a.id for a in page_attempts],
                 question__question_type="ES",
                 graded_at__isnull=True,
-            ).exists()
+            ).values_list("attempt_id", flat=True)
+        )
+        for attempt in page_attempts:
+            attempt.has_ungraded_essays = attempt.id in ungraded_attempt_ids
 
         context["page_type"] = "grade"
 


### PR DESCRIPTION
## Problem
`GradingDashboard` and `QuizGradingTab` set a `has_ungraded_essays` flag on each attempt by running an `.exists()` query **per attempt** inside a Python loop. With `paginate_by = 50`, opening a grading page issued up to ~50 extra queries (a classic N+1).

## Fix
Replace the per-attempt loop with a single batched query in each view's `get_context_data`:
1. Collect the current page's attempt ids.
2. In **one** query, fetch the set of attempt ids that still have an ungraded essay answer (`attempt_id__in=[...]` + `question_type='ES'` + `graded_at IS NULL`), returning only `attempt_id`.
3. Set the flag via in-memory `set` membership.

The filter conditions are identical to before, so **behavior is unchanged** — only the query count drops from N to a constant.

## Tests
`judge/tests/test_quiz_nplus1.py` asserts the number of `quiz_answer` queries stays **constant** as the page grows from 1 → 5 attempts (covers both views). RED before the fix (2 → 6), GREEN after (2 → 2). Full quiz suite (`test_quiz`, 60 tests) passes — no behavior regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)