### PR TITLE
Fix 500 on course grades pages for anonymous users

### DIFF
--- a/judge/tests/test_course_grades_anonymous.py
+++ b/judge/tests/test_course_grades_anonymous.py
@@ -1,0 +1,54 @@
+"""Regression test: anonymous access to a course grades page must 404, not 500.
+
+An anonymous user (no profile) hitting a course grades-lesson page used to crash
+with `AttributeError: 'NoneType' object has no attribute 'id'` — the view ran to
+get_context_data (the access 404 check fires only afterwards), where
+_get_unlocked_lessons -> get_lesson_lock_status -> bulk_calculate_lessons_progress
+did `[s.id for s in [None]]`. The view now bails out for a None profile, so the
+access mixin returns a clean 404.
+"""
+
+from django.test import TestCase
+from django.urls import reverse
+
+from judge.models import Course, CourseLesson, CourseLessonPrerequisite
+
+
+class CourseGradesAnonymousTest(TestCase):
+    def setUp(self):
+        self.course = Course.objects.create(
+            name="Anon Course",
+            slug="anon-course",
+            about="about",
+            is_public=True,
+            is_open=True,
+        )
+        self.lesson = CourseLesson.objects.create(
+            course=self.course,
+            title="Lesson 1",
+            content="content",
+            order=1,
+            points=100,
+        )
+        self.lesson2 = CourseLesson.objects.create(
+            course=self.course,
+            title="Lesson 2",
+            content="content",
+            order=2,
+            points=100,
+        )
+        # A real prerequisite makes get_lesson_lock_status compute grades
+        # (it short-circuits when there are none) — this is the path that used
+        # to crash for a None (anonymous) profile.
+        CourseLessonPrerequisite.objects.create(
+            course=self.course,
+            source_order=1,
+            target_order=2,
+            required_percentage=50,
+        )
+
+    def test_anonymous_grades_lesson_returns_404_not_500(self):
+        url = reverse("course_grades_lesson", args=[self.course.slug, self.lesson.id])
+        response = self.client.get(url)
+        # Anonymous is not a course member -> clean 404 (used to be a 500 crash).
+        self.assertEqual(response.status_code, 404)

--- a/judge/views/course.py
+++ b/judge/views/course.py
@@ -1662,6 +1662,13 @@ def _get_unlocked_lessons(course, profile, is_editable):
     if is_editable:
         return list(all_lessons)
 
+    # Anonymous users have no profile and thus no per-user unlock state.
+    # They are not course members, so the access mixin returns 404 for them
+    # anyway; bail out before computing grades, which would otherwise crash in
+    # bulk_calculate_lessons_progress ('NoneType' object has no attribute 'id').
+    if profile is None:
+        return []
+
     lock_status = get_lesson_lock_status(profile, course)
     return [lesson for lesson in all_lessons if not lock_status.get(lesson.id, False)]
 


### PR DESCRIPTION
## Problem (production 500)
An anonymous user hitting a course grades page (e.g. `GET /course/<slug>/grades/lesson/<id>`) returns **500** with:
```
AttributeError: 'NoneType' object has no attribute 'id'
```
Raised in `CourseStudentResultsLesson` → `get_context_data` → `_get_unlocked_lessons` → `get_lesson_lock_status` → `bulk_calculate_lessons_progress`, at `student_ids = [s.id for s in students]` where `students == [None]` (the anonymous user's `request.profile`).

## Why it happens
`CourseAccessibleMixin` raises its 404 **after** `super().dispatch()` runs the view, so `get_context_data` executes for inaccessible users. For a `None` profile, the grade-calculation path crashes — but only when the course has lesson **prerequisites** (otherwise `get_lesson_lock_status` short-circuits before computing grades), which is why it only shows up on some courses.

## Fix
`_get_unlocked_lessons` now returns `[]` for a `None` profile. Anonymous users are never course members, so the access mixin still returns a clean **404** — it just no longer crashes on the way there. Covers both call sites (course-detail sidebar and grades-lesson sidebar).

## Tests
`judge/tests/test_course_grades_anonymous.py` builds a course with a prerequisite and asserts an anonymous GET returns 404. Verified red→green (reproduces the exact `AttributeError` without the fix). Existing `test_course_prerequisites` (62 tests) still pass.

## Note
Deeper follow-up (not in this hotfix): the course access mixins check accessibility *after* rendering the view (`res = super().dispatch(...); if not accessible: raise Http404()`), which is what let an inaccessible request reach the crashing code. Moving the check before `dispatch` would prevent this whole class of issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)