### PR TITLE
Course teachers can view their students' submissions

### DIFF
--- a/judge/models/course.py
+++ b/judge/models/course.py
@@ -378,12 +378,25 @@ class CourseLessonProblem(models.Model):
     order = models.IntegerField(verbose_name=_("order"), default=0)
     score = models.IntegerField(verbose_name=_("score"), default=0)
 
+    def _dirty_editors_problem_cache(self, course):
+        # Adding/removing a problem changes which problems each course editor can see
+        # submissions for. Invalidate the cached set for every editor of the course so
+        # access updates immediately. See Submission.is_accessible_by.
+        from judge.utils.problems import editable_course_problem_ids
+
+        for profile in Profile.objects.filter(
+            course_roles__course=course,
+            course_roles__role__in=EDITABLE_ROLES,
+        ):
+            editable_course_problem_ids.dirty(profile)
+
     def save(self, *args, **kwargs):
         super().save(*args, **kwargs)
         # Mark all users for recalculation when lesson content changes
         from judge.utils.course_prerequisites import mark_course_for_recalculation
 
         mark_course_for_recalculation(self.lesson.course)
+        self._dirty_editors_problem_cache(self.lesson.course)
 
     def delete(self, *args, **kwargs):
         course = self.lesson.course
@@ -392,6 +405,7 @@ class CourseLessonProblem(models.Model):
         from judge.utils.course_prerequisites import mark_course_for_recalculation
 
         mark_course_for_recalculation(course)
+        self._dirty_editors_problem_cache(course)
 
 
 class CourseContest(models.Model):

--- a/judge/models/course.py
+++ b/judge/models/course.py
@@ -248,6 +248,23 @@ class CourseRole(models.Model):
             couresrole.role = role
             couresrole.save()
 
+    def _dirty_editable_course_problem_cache(self, user):
+        # A role change/removal alters which problems this user (as a course editor)
+        # can see submissions for. Invalidate the cached set so access is revoked
+        # immediately, not after the cache timeout. See Submission.is_accessible_by.
+        from judge.utils.problems import editable_course_problem_ids
+
+        editable_course_problem_ids.dirty(user)
+
+    def save(self, *args, **kwargs):
+        super().save(*args, **kwargs)
+        self._dirty_editable_course_problem_cache(self.user)
+
+    def delete(self, *args, **kwargs):
+        user = self.user
+        super().delete(*args, **kwargs)
+        self._dirty_editable_course_problem_cache(user)
+
     class Meta:
         unique_together = ("course", "user")
 

--- a/judge/models/submission.py
+++ b/judge/models/submission.py
@@ -261,9 +261,15 @@ class Submission(models.Model):
             user_completed_ids,
             user_tester_ids,
             user_editable_ids,
+            editable_course_problem_ids,
         )
 
         if problem_id in user_editable_ids(profile):
+            return True
+
+        # Course editors (teacher/assistant) may view submissions to problems in
+        # their own courses. NOTE: site-wide visibility change — flagged for owner.
+        if problem_id in editable_course_problem_ids(profile):
             return True
 
         if self.problem_id in user_completed_ids(profile):

--- a/judge/tests/test_teacher_submission_access.py
+++ b/judge/tests/test_teacher_submission_access.py
@@ -1,0 +1,149 @@
+"""Course editors (teacher/assistant) can view their students' submissions.
+
+Submission.is_accessible_by grants access when the submission's problem belongs to a
+lesson of a course the viewer edits (TEACHER/ASSISTANT, or superuser). Scoped: only
+problems in their own courses; submissions outside stay private.
+
+NOTE: this loosens a site-wide access rule — flagged for owner (cuom1999) review.
+"""
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+
+from judge.models import (
+    Course,
+    CourseLesson,
+    CourseLessonProblem,
+    CourseRole,
+    Language,
+    Problem,
+    ProblemGroup,
+    Profile,
+    Submission,
+)
+from judge.models.course import RoleInCourse
+from judge.models.submission import SubmissionSource
+
+
+class TeacherSubmissionAccessTest(TestCase):
+    fixtures = ["language_small"]
+
+    def setUp(self):
+        self.lang = Language.objects.first()
+        self.group = ProblemGroup.objects.create(name="g", full_name="Group")
+
+        self.teacher = self._profile("teacher")
+        self.assistant = self._profile("assistant")
+        self.student = self._profile("student")
+        self.peer = self._profile("peer")  # enrolled student, not owner
+        self.other_teacher = self._profile(
+            "other_teacher"
+        )  # teaches a DIFFERENT course
+
+        self.course = Course.objects.create(
+            name="C", slug="c", about="a", is_public=True, is_open=True
+        )
+        CourseRole.objects.create(
+            course=self.course, user=self.teacher, role=RoleInCourse.TEACHER
+        )
+        CourseRole.objects.create(
+            course=self.course, user=self.assistant, role=RoleInCourse.ASSISTANT
+        )
+        CourseRole.objects.create(
+            course=self.course, user=self.student, role=RoleInCourse.STUDENT
+        )
+        CourseRole.objects.create(
+            course=self.course, user=self.peer, role=RoleInCourse.STUDENT
+        )
+
+        self.lesson = CourseLesson.objects.create(
+            course=self.course, title="L1", content="c", order=1, points=100
+        )
+        # Private problem (NOT public) so access can ONLY come from the course-editor
+        # rule, not the "solved a public problem" rule.
+        self.problem = Problem.objects.create(
+            code="p1",
+            name="P1",
+            description="d",
+            group=self.group,
+            time_limit=1.0,
+            memory_limit=65536,
+            points=100.0,
+            is_public=False,
+        )
+        CourseLessonProblem.objects.create(
+            lesson=self.lesson, problem=self.problem, order=1, score=100
+        )
+        self.sub = self._submission(self.student, self.problem)
+
+        # A standalone problem in NO course, with a student submission.
+        self.standalone = Problem.objects.create(
+            code="p2",
+            name="P2",
+            description="d",
+            group=self.group,
+            time_limit=1.0,
+            memory_limit=65536,
+            points=100.0,
+            is_public=False,
+        )
+        self.standalone_sub = self._submission(self.student, self.standalone)
+
+    def _profile(self, name):
+        user = User.objects.create_user(name, f"{name}@x.com", "pw")
+        profile, _ = Profile.objects.get_or_create(
+            user=user, defaults={"language": self.lang}
+        )
+        return profile
+
+    def _submission(self, profile, problem):
+        sub = Submission.objects.create(
+            user=profile,
+            problem=problem,
+            language=self.lang,
+            status="D",
+            result="AC",
+            points=100,
+            case_points=100,
+            case_total=100,
+            time=0.1,
+            memory=1024,
+        )
+        SubmissionSource.objects.create(submission=sub, source="print(1)")
+        return sub
+
+    # --- the new course-editor rule ---
+    def test_teacher_can_access_student_submission_in_their_course(self):
+        self.assertTrue(self.sub.is_accessible_by(self.teacher))
+
+    def test_assistant_can_access_student_submission_in_their_course(self):
+        self.assertTrue(self.sub.is_accessible_by(self.assistant))
+
+    # --- scope limits ---
+    def test_teacher_cannot_access_submission_outside_their_courses(self):
+        # standalone problem isn't in any course this teacher edits
+        self.assertFalse(self.standalone_sub.is_accessible_by(self.teacher))
+
+    def test_other_course_teacher_cannot_access(self):
+        # other_teacher edits a different course, not this one
+        other_course = Course.objects.create(
+            name="C2", slug="c2", about="a", is_public=True, is_open=True
+        )
+        CourseRole.objects.create(
+            course=other_course, user=self.other_teacher, role=RoleInCourse.TEACHER
+        )
+        self.assertFalse(self.sub.is_accessible_by(self.other_teacher))
+
+    def test_peer_student_cannot_access(self):
+        # enrolled classmate, not owner, hasn't solved a public problem -> no access
+        self.assertFalse(self.sub.is_accessible_by(self.peer))
+
+    def test_owner_can_still_access(self):
+        self.assertTrue(self.sub.is_accessible_by(self.student))
+
+    # --- integration: the submission detail page honors the same rule ---
+    def test_teacher_can_open_submission_status_page(self):
+        self.client.force_login(self.teacher.user)
+        resp = self.client.get(reverse("submission_status", args=[self.sub.id]))
+        self.assertEqual(resp.status_code, 200)

--- a/judge/tests/test_teacher_submission_access.py
+++ b/judge/tests/test_teacher_submission_access.py
@@ -147,3 +147,17 @@ class TeacherSubmissionAccessTest(TestCase):
         self.client.force_login(self.teacher.user)
         resp = self.client.get(reverse("submission_status", args=[self.sub.id]))
         self.assertEqual(resp.status_code, 200)
+
+    # --- cache invalidation: revoking the role must revoke access immediately ---
+    def test_demoting_teacher_to_student_revokes_access(self):
+        role = CourseRole.objects.get(course=self.course, user=self.teacher)
+        self.assertTrue(self.sub.is_accessible_by(self.teacher))  # warms the cache
+        role.role = RoleInCourse.STUDENT
+        role.save()
+        self.assertFalse(self.sub.is_accessible_by(self.teacher))
+
+    def test_removing_role_revokes_access(self):
+        role = CourseRole.objects.get(course=self.course, user=self.teacher)
+        self.assertTrue(self.sub.is_accessible_by(self.teacher))  # warms the cache
+        role.delete()
+        self.assertFalse(self.sub.is_accessible_by(self.teacher))

--- a/judge/tests/test_teacher_submission_access.py
+++ b/judge/tests/test_teacher_submission_access.py
@@ -161,3 +161,21 @@ class TeacherSubmissionAccessTest(TestCase):
         self.assertTrue(self.sub.is_accessible_by(self.teacher))  # warms the cache
         role.delete()
         self.assertFalse(self.sub.is_accessible_by(self.teacher))
+
+    # --- cache invalidation: changing a lesson's problem set updates editor access ---
+    def test_adding_problem_to_lesson_grants_access(self):
+        # standalone problem isn't in any course yet -> teacher can't see it
+        self.assertFalse(
+            self.standalone_sub.is_accessible_by(self.teacher)
+        )  # warms cache
+        CourseLessonProblem.objects.create(
+            lesson=self.lesson, problem=self.standalone, order=2, score=50
+        )
+        self.assertTrue(self.standalone_sub.is_accessible_by(self.teacher))
+
+    def test_removing_problem_from_lesson_revokes_access(self):
+        self.assertTrue(self.sub.is_accessible_by(self.teacher))  # warms cache
+        CourseLessonProblem.objects.get(
+            lesson=self.lesson, problem=self.problem
+        ).delete()
+        self.assertFalse(self.sub.is_accessible_by(self.teacher))

--- a/judge/utils/problems.py
+++ b/judge/utils/problems.py
@@ -13,7 +13,12 @@ from django.utils.translation import gettext as _, gettext_noop
 from django.http import Http404
 
 from judge.models import Problem, Submission
-from judge.models.course import BestSubmission
+from judge.models.course import (
+    BestSubmission,
+    CourseLessonProblem,
+    CourseRole,
+    EDITABLE_ROLES,
+)
 from judge.ml.vector_store import VectorStore
 from judge.caching import cache_wrapper
 
@@ -23,6 +28,7 @@ __all__ = [
     "user_completed_ids",
     "user_editable_ids",
     "user_tester_ids",
+    "editable_course_problem_ids",
 ]
 
 
@@ -46,6 +52,31 @@ def user_editable_ids(profile):
         .distinct()
     )
     return result
+
+
+@cache_wrapper(prefix="editable_course_problems_v1")
+def editable_course_problem_ids(profile):
+    """Problem ids in lessons of courses the profile can edit (TEACHER/ASSISTANT).
+
+    Lets course editors view their students' submissions to those problems. Superusers
+    are already covered earlier (view_all_submission), so this only matters for
+    non-superuser course editors. Cached per profile; stale up to the cache timeout
+    after course-role / lesson-problem changes (acceptable).
+    """
+    if profile is None:
+        return set()
+    course_ids = list(
+        CourseRole.objects.filter(user=profile, role__in=EDITABLE_ROLES).values_list(
+            "course_id", flat=True
+        )
+    )
+    if not course_ids:
+        return set()
+    return set(
+        CourseLessonProblem.objects.filter(lesson__course_id__in=course_ids)
+        .values_list("problem_id", flat=True)
+        .distinct()
+    )
 
 
 @cache_wrapper(prefix="contest_complete")


### PR DESCRIPTION
## Summary
Lets a **course editor (TEACHER / ASSISTANT / superuser)** view a student's submission when the problem belongs to a lesson of a course they edit — so teachers can open submissions from the lesson-grades popup and the submission detail page.

⚠️ **POLICY CHANGE — needs @cuom1999 sign-off.** This loosens a **site-wide** access rule (`Submission.is_accessible_by`, used by the submission detail page, lists, and APIs). Scoped to problems in the viewer's own courses; everything else stays private.

## What changed
- **`Submission.is_accessible_by`**: new branch — grant if the problem is in a course the viewer edits.
- **`judge/utils/problems.py`**: cached helper `editable_course_problem_ids(profile)` (mirrors `user_editable_ids`) → avoids per-row N+1.
- **Cache invalidation** (so revoking access takes effect immediately, not after timeout):
  - `CourseRole.save()/delete()` → dirty the user's set (role change / removal).
  - `CourseLessonProblem.save()/delete()` → dirty all editors of the course (problem added/removed).
- No template change needed — the popups already gate on `is_accessible_by(request.profile)`.

## Test Plan
- [x] `judge/tests/test_teacher_submission_access.py` (11): teacher/assistant can view in-course; cannot view standalone / other-course; peer cannot; owner can; submission detail page 200 for teacher; **demoting/removing role revokes immediately**; **adding/removing a lesson problem updates access**.

## Security review checklist (for @cuom1999)
- [ ] OK to grant course editors site-wide read access to submissions of problems in their courses?
- [ ] Roles correct = TEACHER + ASSISTANT + superuser?
- [ ] Acceptable that this also exposes contest submissions for course problems to course editors (editors are trusted; mid-contest fairness is about competitors, not staff)?

## Known follow-ups (not in this PR)
- Bulk ops bypass instance `save()/delete()` (`QuerySet.update()/delete()`, Course cascade-delete, admin bulk actions) — current app views use instance ops, so covered; admin/cascade aren't.
- Pre-existing `CourseRole.make_role` updates role without `.save()` (no-op) — separate bug.

## Notes
- **Stacked on #269** (`mimibetty/auth-redirect-friendly-errors`); rebase to `master` once #269 merges. Independent of the sibling popup PR (#275).

🤖 Generated with [Claude Code](https://claude.com/claude-code)