### PR TITLE
feat(contest): log who rated a contest in admin history

### DIFF
--- a/judge/admin/contest.py
+++ b/judge/admin/contest.py
@@ -12,6 +12,7 @@ from django.urls import reverse, reverse_lazy
 from django.utils import timezone
 from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _, ngettext
+import reversion
 from reversion_compare.admin import CompareVersionAdmin
 
 from django_ace import AceWidget
@@ -398,6 +399,21 @@ class ContestAdmin(CompareVersionAdmin):
             reverse("admin:judge_contest_change", args=(contest_id,))
         )
 
+    def log_contests_rated(self, request, contests, comment):
+        # Record who rated which contest (and when) on the contest's /history/
+        # page. That page is rendered by reversion-compare from reversion
+        # revisions (not Django's LogEntry table), so we snapshot each rated
+        # contest into a single revision tagged with the acting user and a
+        # comment. The rate views call contest.rate()/rate_contest() directly,
+        # which never touches the Contest row, so without this nothing is logged.
+        if not contests:
+            return
+        with reversion.create_revision():
+            reversion.set_user(request.user)
+            reversion.set_comment(comment)
+            for contest in contests:
+                reversion.add_to_revision(contest)
+
     def rate_all_view(self, request):
         if not request.user.has_perm("judge.contest_rating"):
             raise PermissionDenied()
@@ -405,10 +421,16 @@ class ContestAdmin(CompareVersionAdmin):
             with connection.cursor() as cursor:
                 cursor.execute("TRUNCATE TABLE `%s`" % Rating._meta.db_table)
             Profile.objects.update(rating=None)
-            for contest in Contest.objects.filter(
-                is_rated=True, end_time__lte=timezone.now()
-            ).order_by("end_time"):
+            rated = list(
+                Contest.objects.filter(
+                    is_rated=True, end_time__lte=timezone.now()
+                ).order_by("end_time")
+            )
+            for contest in rated:
                 rate_contest(contest)
+            self.log_contests_rated(
+                request, rated, _("Rated via “Rate all ratable contests”.")
+            )
         return HttpResponseRedirect(reverse("admin:judge_contest_changelist"))
 
     def rate_view(self, request, id):
@@ -418,7 +440,8 @@ class ContestAdmin(CompareVersionAdmin):
         if not contest.is_rated or not contest.ended:
             raise Http404()
         with transaction.atomic():
-            contest.rate()
+            rated = contest.rate()
+            self.log_contests_rated(request, rated, _("Rated this contest."))
         return HttpResponseRedirect(
             request.META.get("HTTP_REFERER", reverse("admin:judge_contest_changelist"))
         )

--- a/judge/models/contest.py
+++ b/judge/models/contest.py
@@ -740,11 +740,15 @@ class Contest(models.Model, PageVotable, Bookmarkable):
         Rating.objects.filter(
             contest__end_time__range=(self.end_time, self._now)
         ).delete()
-        for contest in Contest.objects.filter(
-            is_rated=True,
-            end_time__range=(self.end_time, self._now),
-        ).order_by("end_time"):
+        rated = list(
+            Contest.objects.filter(
+                is_rated=True,
+                end_time__range=(self.end_time, self._now),
+            ).order_by("end_time")
+        )
+        for contest in rated:
             rate_contest(contest)
+        return rated
 
     class Meta:
         permissions = (

--- a/locale/vi/LC_MESSAGES/django.po
+++ b/locale/vi/LC_MESSAGES/django.po
@@ -14066,3 +14066,11 @@ msgstr "Bạn không có quyền truy cập \"%s\"."
 
 msgid "The page \"%s\" doesn't exist or you don't have permission to view it."
 msgstr "Trang \"%s\" không tồn tại hoặc bạn không có quyền truy cập."
+
+#: judge/admin/contest.py:432
+msgid "Rated via “Rate all ratable contests”."
+msgstr "Đã rate qua “Rate tất cả kỳ thi xếp hạng”."
+
+#: judge/admin/contest.py:444
+msgid "Rated this contest."
+msgstr "Đã rate kỳ thi này."


### PR DESCRIPTION
Record the acting user, timestamp, and action in each rated contest's reversion history when an admin uses the Rate or Rate-all admin actions, which previously left no audit trail.